### PR TITLE
prepare for turbo

### DIFF
--- a/.changeset/spotty-grapes-design.md
+++ b/.changeset/spotty-grapes-design.md
@@ -1,0 +1,5 @@
+---
+"mdxts": minor
+---
+
+Adds initial support for Next.js [Turbopack](https://nextjs.org/docs/app/api-reference/next-config-js/turbo) locally.

--- a/packages/mdxts/src/loader/index.ts
+++ b/packages/mdxts/src/loader/index.ts
@@ -201,7 +201,13 @@ export default async function loader(
           })
 
           const objectLiteralText = `{${filePaths
-            .map((filePath) => `"${filePath}": import('${filePath}')`)
+            .map((filePath) => {
+              const relativeFilePath = relative(workingDirectory, filePath)
+              const normalizedRelativePath = relativeFilePath.startsWith('.')
+                ? relativeFilePath
+                : `.${sep}${relativeFilePath}`
+              return `'${filePath}': import('${normalizedRelativePath}')`
+            })
             .join(', ')}}`
 
           call.insertArguments(0, [objectLiteralText])


### PR DESCRIPTION
This prepares MDXTS to work with [Turbopack](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders). However, it seems there are still some bugs detailed below.

It looks like `use client` directives aren't being handled correctly and result in the following import error:

<img width="1035" alt="image" src="https://github.com/souporserious/mdxts/assets/2762082/ad111c3c-32c8-43cc-a0e1-f77fc702bbbb">

Adding dynamic imports throw the following error in the console, but seems to compile and render fine on the client:

`Error: could not resolve "./docs/getting-started.mdx" into a module`