### PR TITLE
front matter validation

### DIFF
--- a/.changeset/warm-crews-begin.md
+++ b/.changeset/warm-crews-begin.md
@@ -1,0 +1,37 @@
+---
+'mdxts': minor
+---
+
+Adds front matter type validation using the generic passed to `createSource`:
+
+```ts
+import { createSource } from 'mdxts'
+
+export const allPosts = createSource<{
+  frontMatter: {
+    title: string
+    date: Date
+    summary: string
+    tags?: string[]
+  }
+}>('posts/**/*.mdx', { baseDirectory: 'posts' })
+```
+
+```posts/markdown-guide.mdx
+---
+title: Hello World
+date: 2021-01-01
+---
+
+# Hello World
+
+This is a post.
+```
+
+Results in the following type error:
+
+```
+Error: Front matter data is incorrect or missing
+[/posts/markdown-guide.mdx] Type '{}' does not satisfy the expected type 'frontMatter'.
+Type '{}' is missing the following properties from type 'frontMatter': summary
+```

--- a/packages/mdxts/package.json
+++ b/packages/mdxts/package.json
@@ -113,7 +113,7 @@
     "@remark-embedder/core": "^3.0.2",
     "@remark-embedder/transformer-codesandbox": "^3.0.0",
     "@sindresorhus/slugify": "^2.2.1",
-    "@tsxmod/utils": "^0.5.0",
+    "@tsxmod/utils": "^0.5.1",
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.3",
     "@types/mdx": "^2.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^2.2.1
         version: 2.2.1
       '@tsxmod/utils':
-        specifier: ^0.5.0
-        version: 0.5.0(ts-morph@21.0.1)
+        specifier: ^0.5.1
+        version: 0.5.1(ts-morph@21.0.1)
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -1974,8 +1974,8 @@ packages:
       path-browserify: 1.0.1
     dev: false
 
-  /@tsxmod/utils@0.5.0(ts-morph@21.0.1):
-    resolution: {integrity: sha512-IQvFYIQbITQDFOhtlk1dA5RFf5xsYM60+42T2ah+8A/k0Htw76bLepIn93r+Hb31g/zt98p6QLohrbLgcafCog==}
+  /@tsxmod/utils@0.5.1(ts-morph@21.0.1):
+    resolution: {integrity: sha512-PuItaMH0WB0hiid4K6UQMVd/BCT+nXnF7biDn5wM8l0Yaarddl/wDdMlVv5R2dknmuZVBlgmqaMojQA8ztXYDw==}
     peerDependencies:
       ts-morph: '>=17.0.0'
     dependencies:


### PR DESCRIPTION
Adds front matter type validation using the generic passed to `createSource`:

```ts
import { createSource } from 'mdxts'

export const allPosts = createSource<{
  frontMatter: {
    title: string
    date: Date
    summary: string
    tags?: string[]
  }
}>('posts/**/*.mdx', { baseDirectory: 'posts' })
```

```posts/markdown-guide.mdx
---
title: Hello World
date: 2021-01-01
---

# Hello World

This is a post.
```

Results in the following type error:

```
Error: Front matter data is incorrect or missing
[/posts/markdown-guide.mdx] Type '{}' does not satisfy the expected type 'frontMatter'.
Type '{}' is missing the following properties from type 'frontMatter': summary
```