### PR TITLE
normalize entry source files

### DIFF
--- a/.changeset/hip-eagles-cheer.md
+++ b/.changeset/hip-eagles-cheer.md
@@ -1,0 +1,39 @@
+---
+'mdxts': minor
+---
+
+Normalizes the internal `getEntrySourceFiles` utility that is responsible for determining what TypeScript data sources are public based on `package.json` exports, index files, and top-level directories.
+
+To determine what source files should be considered public when dealing with package exports, `createSource` gets two new options used to remap `package.json` exports to their original source files:
+
+```ts
+import { createSource } from 'mdxts'
+
+const allPackages = createSource('../packages/mdxts/src/**/*.{ts,tsx}', {
+  sourceDirectory: 'src',
+  outputDirectory: 'dist',
+})
+```
+
+Using a subset of the `mdxts` `package.json` exports as an example:
+
+```json
+"exports": {
+  ".": {
+    "types": "./dist/src/index.d.ts",
+    "import": "./dist/src/index.js",
+    "require": "./dist/cjs/index.js"
+  },
+  "./components": {
+    "types": "./dist/src/components/index.d.ts",
+    "import": "./dist/src/components/index.js",
+    "require": "./dist/cjs/components/index.js"
+  },
+},
+```
+
+These would be remapped to their original source files, filtering out any paths gathered from the `createSource` pattern not explicitly exported:
+
+```json
+["../packages/mdxts/src/index.ts", "../packages/mdxts/src/components/index.ts"]
+```

--- a/packages/mdxts/package.json
+++ b/packages/mdxts/package.json
@@ -132,7 +132,7 @@
     "hast-util-to-string": "^3.0.0",
     "mdast-util-to-string": "^4.0.0",
     "minimatch": "^9.0.4",
-    "read-package-up": "^11.0.0",
+    "read-pkg-up": "^7.0.1",
     "rehype-infer-reading-time-meta": "^2.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^3.0.1",

--- a/packages/mdxts/src/components/ContentRefresh.tsx
+++ b/packages/mdxts/src/components/ContentRefresh.tsx
@@ -4,6 +4,10 @@ import { useRouter } from 'next/navigation'
 
 const ws = new WebSocket(`ws://localhost:${process.env.MDXTS_REFRESH_PORT}/ws`)
 
+/**
+ * Refreshes the Next.js development server when MDX or TypeScript source files change.
+ * @internal
+ */
 export function ContentRefresh({
   mdxPath,
   tsPath,

--- a/packages/mdxts/src/components/Context.tsx
+++ b/packages/mdxts/src/components/Context.tsx
@@ -1,5 +1,9 @@
 import { createContext } from '../utils/context'
 
+/**
+ * Manages passing the current tree's `workingDirectory` to descendant Server Components.
+ * @internal
+ */
 export const Context = createContext<{
   workingDirectory?: string
 }>({

--- a/packages/mdxts/src/components/CopyButton.tsx
+++ b/packages/mdxts/src/components/CopyButton.tsx
@@ -1,6 +1,10 @@
 'use client'
 import * as React from 'react'
 
+/**
+ * Copies a value to the user's clipboard.
+ * @internal
+ */
 export function CopyButton({
   value,
   style,

--- a/packages/mdxts/src/components/PackageInstall.tsx
+++ b/packages/mdxts/src/components/PackageInstall.tsx
@@ -14,7 +14,10 @@ const packageManagers = {
   yarn: 'yarn add',
 }
 
-/** Renders a package install command with a variant for each package manager. */
+/**
+ * Renders a package install command with a variant for each package manager.
+ * @internal
+ */
 export async function PackageInstall({
   packages,
   style,

--- a/packages/mdxts/src/components/actions.ts
+++ b/packages/mdxts/src/components/actions.ts
@@ -1,6 +1,10 @@
 'use server'
 import { readFile, writeFile } from 'node:fs/promises'
 
+/**
+ * Modify the MDX code block source to allow errors.
+ * @internal
+ */
 export async function showErrors({
   sourcePath,
   sourcePathLine,

--- a/packages/mdxts/src/index.ts
+++ b/packages/mdxts/src/index.ts
@@ -93,6 +93,18 @@ export function createSource<Type extends { frontMatter: Record<string, any> }>(
      * the hostname (e.g. `/docs` in `https://mdxts.com/docs`).
      */
     basePathname?: string
+
+    /**
+     * The source directory used to calculate package export paths. This is useful when the source is
+     * located in a different workspace than the project rendering it.
+     */
+    sourceDirectory?: string
+
+    /**
+     * The output directory for built files used to calculate package export paths. This is useful
+     * when the source is located in a different workspace than the project rendering it.
+     */
+    outputDirectory?: string | string[]
   } = {}
 ) {
   let allModules = arguments[2] as AllModules
@@ -111,13 +123,20 @@ export function createSource<Type extends { frontMatter: Record<string, any> }>(
     ])
   )
 
-  const { baseDirectory = '', basePathname = '' } = options || {}
+  const {
+    baseDirectory = '',
+    basePathname = '',
+    sourceDirectory,
+    outputDirectory,
+  } = options || {}
   const allData = getAllData<Type>({
     allModules,
     globPattern,
     project,
     baseDirectory,
     basePathname,
+    sourceDirectory,
+    outputDirectory,
   })
   const filteredDataKeys = Object.keys(allData).filter((pathname) => {
     const moduleData = allData[pathname]

--- a/packages/mdxts/src/loader/index.ts
+++ b/packages/mdxts/src/loader/index.ts
@@ -5,6 +5,8 @@ import globParent from 'glob-parent'
 import { Node, Project, SyntaxKind } from 'ts-morph'
 import { addComputedTypes, resolveObject } from '@tsxmod/utils'
 
+import { project } from '../components/project'
+import { getEntrySourceFiles } from '../utils/get-entry-source-files'
 import { getExportedSourceFiles } from '../utils/get-exported-source-files'
 
 /**
@@ -90,9 +92,6 @@ export default async function loader(
 
           /** Search for MDX files named the same as the source files (e.g. `Button.mdx` for `Button.tsx`) */
           if (!isMdxPattern) {
-            const { getEntrySourceFiles } = await import(
-              '../utils/get-entry-source-files'
-            )
             const allSourceFilePaths = await glob(globPattern, {
               cwd: workingDirectory,
               ignore: ['**/*.examples.(ts|tsx)'],
@@ -118,6 +117,7 @@ export default async function loader(
               outputDirectory?: string
             }
             const entrySourceFiles = getEntrySourceFiles(
+              project,
               allPaths,
               sourceDirectory,
               outputDirectory

--- a/packages/mdxts/src/loader/index.ts
+++ b/packages/mdxts/src/loader/index.ts
@@ -3,7 +3,7 @@ import { dirname, join, relative, resolve, sep } from 'node:path'
 import { glob } from 'fast-glob'
 import globParent from 'glob-parent'
 import { Node, Project, SyntaxKind } from 'ts-morph'
-import { addComputedTypes } from '@tsxmod/utils'
+import { addComputedTypes, resolveObject } from '@tsxmod/utils'
 
 import { getExportedSourceFiles } from '../utils/get-exported-source-files'
 
@@ -108,12 +108,19 @@ export default async function loader(
               )
             }
 
+            const optionsArgument = createSourceCall.getArguments()[1]
+            const { sourceDirectory, outputDirectory } = (
+              Node.isObjectLiteralExpression(optionsArgument)
+                ? resolveObject(optionsArgument)
+                : {}
+            ) as {
+              sourceDirectory?: string
+              outputDirectory?: string
+            }
             const entrySourceFiles = getEntrySourceFiles(
               allPaths,
-              'src',
-              ['dist/src', 'dist/cjs']
-              // sourceDirectory,
-              // outputDirectory
+              sourceDirectory,
+              outputDirectory
             )
             const exportedSourceFiles = getExportedSourceFiles(entrySourceFiles)
             const exportedSourceFilePaths = entrySourceFiles

--- a/packages/mdxts/src/next/index.ts
+++ b/packages/mdxts/src/next/index.ts
@@ -3,6 +3,7 @@ import { NextConfig } from 'next'
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
 import { dirname, resolve } from 'node:path'
 import createMdxPlugin from '@next/mdx'
+import { sync as readPackageUpSync } from 'read-pkg-up'
 import type { bundledThemes } from 'shiki'
 
 import { getMdxPlugins } from '../mdx-plugins'
@@ -88,8 +89,7 @@ export function createMdxtsPlugin(pluginOptions: PluginOptions) {
       nextConfig.env.MDXTS_SITE_URL = siteUrl
 
       if (!theme.endsWith('.json')) {
-        const { readPackageUp } = await import('read-package-up')
-        const mdxtsPackageJson = await readPackageUp({ cwd: __dirname })
+        const mdxtsPackageJson = readPackageUpSync({ cwd: __dirname })
         themePath = resolve(
           dirname(mdxtsPackageJson!.path),
           `node_modules/tm-themes/themes/${theme}.json`

--- a/packages/mdxts/src/utils/get-all-data.test.ts
+++ b/packages/mdxts/src/utils/get-all-data.test.ts
@@ -133,8 +133,8 @@ describe('getAllData', () => {
 
   it('includes only public files based on package.json exports', (done) => {
     jest.isolateModules(() => {
-      jest.mock('read-package-up', () => ({
-        readPackageUpSync: () => ({
+      jest.mock('read-pkg-up', () => ({
+        sync: () => ({
           packageJson: {
             name: 'mdxts',
             exports: {

--- a/packages/mdxts/src/utils/get-all-data.ts
+++ b/packages/mdxts/src/utils/get-all-data.ts
@@ -99,6 +99,7 @@ export function getAllData<Type extends { frontMatter: Record<string, any> }>({
   const sharedDirectoryPath = getSharedDirectoryPath(...allPaths)
   const packageMetadata = getPackageMetadata(...allPaths)
   const entrySourceFiles = getEntrySourceFiles(
+    project,
     allPaths,
     sourceDirectory,
     outputDirectory

--- a/packages/mdxts/src/utils/get-all-data.ts
+++ b/packages/mdxts/src/utils/get-all-data.ts
@@ -1,6 +1,5 @@
 import parseTitle from 'title'
 import { dirname, join, sep } from 'node:path'
-import { readPackageUpSync } from 'read-package-up'
 import type { ExportedDeclarations, Project } from 'ts-morph'
 import { Directory, SourceFile } from 'ts-morph'
 import { getSymbolDescription, resolveExpression } from '@tsxmod/utils'
@@ -8,6 +7,7 @@ import matter from 'gray-matter'
 
 import { filePathToPathname } from './file-path-to-pathname'
 import { getExamplesFromSourceFile } from './get-examples'
+import { getEntrySourceFiles } from './get-entry-source-files'
 import { getExportedSourceFiles } from './get-exported-source-files'
 import { getExportedTypes } from './get-exported-types'
 import { getGitMetadata } from './get-git-metadata'
@@ -56,9 +56,10 @@ export function getAllData<Type extends { frontMatter: Record<string, any> }>({
   allModules,
   globPattern,
   project,
-  sourceDirectory = 'src',
   baseDirectory,
   basePathname = '',
+  sourceDirectory = 'src',
+  outputDirectory = 'dist',
 }: {
   /** A map of all MDX modules keyed by their pathname. */
   allModules: AllModules
@@ -69,14 +70,17 @@ export function getAllData<Type extends { frontMatter: Record<string, any> }>({
   /** The ts-morph project to use for parsing source files. */
   project: Project
 
-  /** The source directory used to calculate package export paths. */
-  sourceDirectory?: string
-
   /** The base directory to use when calculating source paths. */
   baseDirectory?: string
 
   /** The base path to use when calculating navigation paths. */
   basePathname?: string
+
+  /** The source directory used to calculate package export paths. */
+  sourceDirectory?: string
+
+  /** The output directory or directories for built files used to calculate package export paths. */
+  outputDirectory?: string | string[]
 }) {
   const typeScriptSourceFiles = /ts(x)?/.test(globPattern)
     ? project.addSourceFilesAtPaths(globPattern)
@@ -94,32 +98,11 @@ export function getAllData<Type extends { frontMatter: Record<string, any> }>({
 
   const sharedDirectoryPath = getSharedDirectoryPath(...allPaths)
   const packageMetadata = getPackageMetadata(...allPaths)
-  let entrySourceFiles = project.addSourceFilesAtPaths(
-    packageMetadata?.exports
-      ? /** If package.json exports found use that for calculating public paths. */
-        Object.keys(packageMetadata.exports).map((key) =>
-          join(
-            packageMetadata.directory,
-            sourceDirectory,
-            key,
-            'index.{js,jsx,ts,tsx}'
-          )
-        )
-      : /** Otherwise default to a common root index file. */
-        join(sharedDirectoryPath, 'index.{js,jsx,ts,tsx}')
+  const entrySourceFiles = getEntrySourceFiles(
+    allPaths,
+    sourceDirectory,
+    outputDirectory
   )
-
-  /** If no root index files exist, assume the top-level directory files are all public exports. */
-  if (
-    typeScriptSourceFiles &&
-    !packageMetadata?.exports &&
-    entrySourceFiles.length === 0
-  ) {
-    entrySourceFiles = project.addSourceFilesAtPaths(
-      join(sharedDirectoryPath, '*.{js,jsx,ts,tsx}')
-    )
-  }
-
   const exportedSourceFiles = getExportedSourceFiles(entrySourceFiles)
   const allPublicPaths = entrySourceFiles
     .concat(exportedSourceFiles)

--- a/packages/mdxts/src/utils/get-entry-source-files.ts
+++ b/packages/mdxts/src/utils/get-entry-source-files.ts
@@ -1,7 +1,6 @@
 import { join, resolve } from 'path'
-import { SourceFile } from 'ts-morph'
+import { Project, SourceFile } from 'ts-morph'
 
-import { project } from '../components/project'
 import { getPackageMetadata } from './get-package-metadata'
 import { getSharedDirectoryPath } from './get-shared-directory-path'
 
@@ -17,6 +16,7 @@ const extensionPatterns = [
  * - Top-level directory files
  */
 export function getEntrySourceFiles(
+  project: Project,
   allPaths: string[],
   sourceDirectory: string = 'src',
   outputDirectory: string | string[] = 'dist'
@@ -70,7 +70,7 @@ export function getEntrySourceFiles(
     if (entrySourceFiles.length === 0) {
       entrySourceFiles = project.addSourceFilesAtPaths(
         extensionPatterns.map((pattern, index) => {
-          const sourcePathPattern = join(sharedDirectoryPath, pattern)
+          const sourcePathPattern = join(sharedDirectoryPath, `*${pattern}`)
           return index === 0 ? sourcePathPattern : `!${sourcePathPattern}`
         })
       )

--- a/packages/mdxts/src/utils/get-entry-source-files.ts
+++ b/packages/mdxts/src/utils/get-entry-source-files.ts
@@ -1,0 +1,81 @@
+import { join, resolve } from 'path'
+import { SourceFile } from 'ts-morph'
+
+import { project } from '../components/project'
+import { getPackageMetadata } from './get-package-metadata'
+import { getSharedDirectoryPath } from './get-shared-directory-path'
+
+const extensionPatterns = [
+  '.{js,jsx,ts,tsx}',
+  '.{examples,test}.{js,jsx,ts,tsx}',
+]
+
+/**
+ * Filters paths and returns TypeScript source files based on the following entry points:
+ * - Package.json exports
+ * - Root index file
+ * - Top-level directory files
+ */
+export function getEntrySourceFiles(
+  allPaths: string[],
+  sourceDirectory: string = 'src',
+  outputDirectory: string | string[] = 'dist'
+): SourceFile[] {
+  if (typeof outputDirectory === 'string') {
+    outputDirectory = [outputDirectory]
+  }
+
+  const sharedDirectoryPath = getSharedDirectoryPath(...allPaths)
+  const packageMetadata = getPackageMetadata(...allPaths)
+  let entrySourceFiles: SourceFile[] = []
+
+  // Use package.json exports for calculating public paths if they exist.
+  if (packageMetadata?.exports) {
+    for (const exportKey in packageMetadata.exports) {
+      const exportValue = packageMetadata.exports[exportKey]
+      let exportPath = exportValue
+
+      if (typeof exportValue === 'object') {
+        exportPath = exportValue.import
+      }
+
+      const sourceFilePaths = extensionPatterns
+        .flatMap((pattern, index) =>
+          (outputDirectory as string[]).map((directory) => {
+            if (!exportPath.includes(directory)) {
+              return
+            }
+            const exportPattern = exportPath
+              .replace(directory, sourceDirectory)
+              .replace(/\.js$/, pattern)
+            const sourcePathPattern = resolve(
+              packageMetadata.directory,
+              exportPattern
+            )
+            // Include the first pattern and exclude examples and tests.
+            return index === 0 ? sourcePathPattern : `!${sourcePathPattern}`
+          })
+        )
+        .filter(Boolean) as string[]
+
+      entrySourceFiles.push(...project.addSourceFilesAtPaths(sourceFilePaths))
+    }
+  } else {
+    // Otherwise default to a common root index file.
+    const defaultSourcePath = join(sharedDirectoryPath, 'index.{js,jsx,ts,tsx}')
+
+    entrySourceFiles.push(...project.addSourceFilesAtPaths(defaultSourcePath))
+
+    // If no root index files exist, assume the top-level directory files are all public exports.
+    if (entrySourceFiles.length === 0) {
+      entrySourceFiles = project.addSourceFilesAtPaths(
+        extensionPatterns.map((pattern, index) => {
+          const sourcePathPattern = join(sharedDirectoryPath, pattern)
+          return index === 0 ? sourcePathPattern : `!${sourcePathPattern}`
+        })
+      )
+    }
+  }
+
+  return entrySourceFiles
+}

--- a/packages/mdxts/src/utils/get-package-metadata.ts
+++ b/packages/mdxts/src/utils/get-package-metadata.ts
@@ -1,5 +1,5 @@
 import { dirname } from 'node:path'
-import { readPackageUpSync } from 'read-package-up'
+import { sync as readPackageUpSync } from 'read-pkg-up'
 
 import { getSharedDirectoryPath } from './get-shared-directory-path'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,9 +197,9 @@ importers:
       prettier:
         specifier: '>=3.0.0'
         version: 3.2.5
-      read-package-up:
-        specifier: ^11.0.0
-        version: 11.0.0
+      read-pkg-up:
+        specifier: ^7.0.1
+        version: 7.0.1
       rehype-infer-reading-time-meta:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1292,9 +1292,6 @@ packages:
   '@types/node@20.11.24':
     resolution: {integrity: sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==}
 
-  '@types/normalize-package-data@2.4.2':
-    resolution: {integrity: sha512-lqa4UEhhv/2sjjIQgjX8B+RBjj47eo0mzGasklVJ78UKGQY1r0VpB9XHDaZZO9qzEFDdy4MrXLuEaSmPrPSe/A==}
-
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -2218,10 +2215,6 @@ packages:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
 
-  find-up-simple@1.0.0:
-    resolution: {integrity: sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==}
-    engines: {node: '>=18'}
-
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -2481,10 +2474,6 @@ packages:
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
-  hosted-git-info@7.0.1:
-    resolution: {integrity: sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==}
-    engines: {node: ^16.14.0 || >=18.0.0}
-
   html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
@@ -2548,10 +2537,6 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
-
-  index-to-position@0.1.2:
-    resolution: {integrity: sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==}
-    engines: {node: '>=18'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3019,10 +3004,6 @@ packages:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
 
-  lru-cache@10.1.0:
-    resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
-    engines: {node: 14 || >=16.14}
-
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
@@ -3479,10 +3460,6 @@ packages:
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
 
-  normalize-package-data@6.0.0:
-    resolution: {integrity: sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==}
-    engines: {node: ^16.14.0 || >=18.0.0}
-
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -3601,10 +3578,6 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
-
-  parse-json@8.1.0:
-    resolution: {integrity: sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==}
-    engines: {node: '>=18'}
 
   parse-latin@4.3.0:
     resolution: {integrity: sha512-TYKL+K98dcAWoCw/Ac1yrPviU8Trk+/gmjQVaoWEFDZmVD4KRg6c/80xKqNNFQObo2mTONgF8trzAf2UTwKafw==}
@@ -3783,10 +3756,6 @@ packages:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
 
-  read-package-up@11.0.0:
-    resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
-    engines: {node: '>=18'}
-
   read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
     engines: {node: '>=8'}
@@ -3794,10 +3763,6 @@ packages:
   read-pkg@5.2.0:
     resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
     engines: {node: '>=8'}
-
-  read-pkg@9.0.1:
-    resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
-    engines: {node: '>=18'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -4460,10 +4425,6 @@ packages:
   type-fest@1.4.0:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
-
-  type-fest@4.8.3:
-    resolution: {integrity: sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw==}
-    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.0:
     resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
@@ -5955,8 +5916,6 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/normalize-package-data@2.4.2': {}
-
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/prop-types@15.7.8': {}
@@ -7032,8 +6991,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  find-up-simple@1.0.0: {}
-
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -7447,10 +7404,6 @@ snapshots:
 
   hosted-git-info@2.8.9: {}
 
-  hosted-git-info@7.0.1:
-    dependencies:
-      lru-cache: 10.1.0
-
   html-encoding-sniffer@3.0.0:
     dependencies:
       whatwg-encoding: 2.0.0
@@ -7507,8 +7460,6 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
-
-  index-to-position@0.1.2: {}
 
   inflight@1.0.6:
     dependencies:
@@ -8146,8 +8097,6 @@ snapshots:
       js-tokens: 4.0.0
 
   lowercase-keys@2.0.0: {}
-
-  lru-cache@10.1.0: {}
 
   lru-cache@4.1.5:
     dependencies:
@@ -9073,13 +9022,6 @@ snapshots:
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
 
-  normalize-package-data@6.0.0:
-    dependencies:
-      hosted-git-info: 7.0.1
-      is-core-module: 2.13.0
-      semver: 7.5.4
-      validate-npm-package-license: 3.0.4
-
   normalize-path@3.0.0: {}
 
   normalize-strings@1.1.1: {}
@@ -9196,12 +9138,6 @@ snapshots:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-
-  parse-json@8.1.0:
-    dependencies:
-      '@babel/code-frame': 7.23.5
-      index-to-position: 0.1.2
-      type-fest: 4.8.3
 
   parse-latin@4.3.0:
     dependencies:
@@ -9349,12 +9285,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  read-package-up@11.0.0:
-    dependencies:
-      find-up-simple: 1.0.0
-      read-pkg: 9.0.1
-      type-fest: 4.8.3
-
   read-pkg-up@7.0.1:
     dependencies:
       find-up: 4.1.0
@@ -9363,18 +9293,10 @@ snapshots:
 
   read-pkg@5.2.0:
     dependencies:
-      '@types/normalize-package-data': 2.4.2
+      '@types/normalize-package-data': 2.4.4
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
-
-  read-pkg@9.0.1:
-    dependencies:
-      '@types/normalize-package-data': 2.4.4
-      normalize-package-data: 6.0.0
-      parse-json: 8.1.0
-      type-fest: 4.8.3
-      unicorn-magic: 0.1.0
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -10127,8 +10049,6 @@ snapshots:
   type-fest@0.8.1: {}
 
   type-fest@1.4.0: {}
-
-  type-fest@4.8.3: {}
 
   typed-array-buffer@1.0.0:
     dependencies:

--- a/site/data.ts
+++ b/site/data.ts
@@ -5,8 +5,7 @@ export const allDocs = createSource('docs/**/*.mdx')
 export const allPackages = createSource('../packages/mdxts/src/**/*.(ts|tsx)', {
   baseDirectory: '../packages/mdxts/src',
   basePathname: 'packages',
-  // outputDirectory: ['dist/src', 'dist/cjs'],
-  outputDirectory: 'dist/src',
+  outputDirectory: ['dist/src', 'dist/cjs'],
 })
 
 export const allData = mergeSources(allDocs, allPackages)

--- a/site/data.ts
+++ b/site/data.ts
@@ -5,6 +5,8 @@ export const allDocs = createSource('docs/**/*.mdx')
 export const allPackages = createSource('../packages/mdxts/src/**/*.(ts|tsx)', {
   baseDirectory: '../packages/mdxts/src',
   basePathname: 'packages',
+  // outputDirectory: ['dist/src', 'dist/cjs'],
+  outputDirectory: 'dist/src',
 })
 
 export const allData = mergeSources(allDocs, allPackages)


### PR DESCRIPTION
This normalizes the internal `getEntrySourceFiles` utility that is responsible for determining what TypeScript data sources are public based on `package.json` exports, index files, and top-level directories. It adds two new options to `createSource` used to remap `package.json` exports to their original source files:

```ts
import { createSource } from 'mdxts'

const allPackages = createSource(
  '../packages/mdxts/src/**/*.{ts,tsx}',
  { sourceDirectory: 'src', outputDirectory: 'dist' }
)
```

Using the `mdxts` `package.json` exports as an example:

```json
"exports": {
  ".": {
    "types": "./dist/src/index.d.ts",
    "import": "./dist/src/index.js",
    "require": "./dist/cjs/index.js"
  },
  "./components": {
    "types": "./dist/src/components/index.d.ts",
    "import": "./dist/src/components/index.js",
    "require": "./dist/cjs/components/index.js"
  },
},
```

These would be remapped to their original source files filtering out any paths from `createSource` not defined as exported:

```json
[
  "../packages/mdxts/src/index.ts",
  "../packages/mdxts/src/components/index.ts",
]
```