### PR TITLE
refine createSource paths

### DIFF
--- a/.changeset/blue-phones-tan.md
+++ b/.changeset/blue-phones-tan.md
@@ -1,0 +1,34 @@
+---
+'mdxts': minor
+---
+
+Refines `paths` returned from `createSource` and `mergeSources`. Based on the glob pattern provided, either a one-dimensional or two-dimensional array of paths will be returned:
+
+```ts
+import { createSource, mergeSources } from 'mdxts'
+
+const allPosts = createSource('posts/*.mdx').paths() // string[]
+const allDocs = createSource('docs/**/*.mdx').paths() // string[][]
+const allPaths = mergeSources(allDocs, allPosts).paths() // string[] | string[][]
+```
+
+Likewise the `get` method will be narrowed to only accept a single pathname or an array of pathname segments:
+
+```ts
+allPosts.get('building-a-button-component-in-react')
+allDocs.get(['examples', 'authoring'])
+```
+
+### Breaking Changes
+
+- The `paths` method now returns a one-dimensional array of paths for a single glob pattern and a two-dimensional array of paths for multiple glob patterns.
+- The `get` method now only accepts a single pathname or an array of pathname segments.
+
+You may need to update your code to accommodate these changes:
+
+```diff
+export function generateStaticParams() {
+--  return allPosts.paths().map((pathname) => ({ slug: pathname.at(-1) }))
+++  return allPosts.paths().map((pathname) => ({ slug: pathname }))
+}
+```

--- a/examples/blog/app/[slug]/page.tsx
+++ b/examples/blog/app/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { allPosts } from '@/data'
 
 export function generateStaticParams() {
-  return allPosts.paths().map((pathname) => ({ slug: pathname.at(-1) }))
+  return allPosts.paths().map((pathname) => ({ slug: pathname }))
 }
 
 export default async function Page({ params }: { params: { slug: string } }) {

--- a/packages/mdxts/src/next/README.mdx
+++ b/packages/mdxts/src/next/README.mdx
@@ -27,7 +27,7 @@ import { notFound } from 'next/navigation'
 
 const allDocs = createSource('docs/**/*.mdx')
 
-type Props = { params: { slug: string } }
+type Props = { params: { slug: string[] } }
 
 export default async function Page({ params }: Props) {
   const doc = await allDocs.get(params.slug)

--- a/site/docs/01.getting-started.mdx
+++ b/site/docs/01.getting-started.mdx
@@ -101,7 +101,7 @@ Use the `get` method from the `allDocs` source we created above to retrieve the 
 import { notFound } from 'next/navigation'
 import { allDocs } from '../../../data'
 
-type Props = { params: { slug: string } }
+type Props = { params: { slug: string[] } }
 
 export default async function Page({ params }: Props) {
   const doc = await allDocs.get(params.slug)
@@ -124,7 +124,7 @@ If the targeted source files are TypeScript files, the exported types will also 
 import { createSource } from 'mdxts'
 import { notFound } from 'next/navigation'
 
-type Props = { params: { slug: string } }
+type Props = { params: { slug: string[] } }
 
 const allComponents = createSource('components/**/*.tsx')
 

--- a/site/docs/02.routing.mdx
+++ b/site/docs/02.routing.mdx
@@ -19,7 +19,7 @@ import { createSource } from 'mdxts'
 
 const allDocs = createSource('docs/**/*.mdx')
 
-export default async function Page({ params }: { params: { slug: string } }) {
+export default async function Page({ params }: { params: { slug: string[] } }) {
   const { Content } = await allDocs.get(params.slug)
   return <Content />
 }
@@ -34,7 +34,7 @@ import { createSource } from 'mdxts'
 
 const allComponents = createSource('components/**/*.tsx')
 
-export default async function Page({ params }: { params: { slug: string } }) {
+export default async function Page({ params }: { params: { slug: string[] } }) {
   const { Content, exportedTypes } = await allComponents.get(params.slug)
   return (
     <>
@@ -85,7 +85,7 @@ export function generateStaticParams() {
   return allDocs.paths().map((pathname) => ({ slug: pathname }))
 }
 
-export default async function Page({ params }: { params: { slug: string } }) {
+export default async function Page({ params }: { params: { slug: string[] } }) {
   const { Content } = await allDocs.get(params.slug)
   return Content ? <Content /> : null
 }


### PR DESCRIPTION
Refines `paths` returned from `createSource` and `mergeSources`. Based on the glob pattern provided, either a one-dimensional or two-dimensional array of paths will be returned:

```ts
import { createSource, mergeSources } from 'mdxts'

const allPosts = createSource('posts/*.mdx').paths() // string[]
const allDocs = createSource('docs/**/*.mdx').paths() // string[][]
const allPaths = mergeSources(allDocs, allPosts).paths() // string[] | string[][]
```

Likewise the `get` method will be narrowed to only accept a single pathname or an array of pathname segments:

```ts
allPosts.get('building-a-button-component-in-react')
allDocs.get(['examples', 'authoring'])
```

### Breaking Changes

- The `paths` method now returns a one-dimensional array of paths for a single glob pattern and a two-dimensional array of paths for multiple glob patterns.
- The `get` method now only accepts a single pathname or an array of pathname segments depending on the file pattern.

You may need to update your code to accommodate these changes:

```diff
export function generateStaticParams() {
  return (
    allPosts.paths().map((pathname) => ({
--      slug: pathname.at(-1)
++      slug: pathname
    }))
  )
}
```