### PR TITLE
add focusedLines prop to CodeBlock

### DIFF
--- a/.changeset/witty-jars-drive.md
+++ b/.changeset/witty-jars-drive.md
@@ -1,5 +1,21 @@
 ---
-"mdxts": minor
+'mdxts': minor
 ---
 
-Adds `focusedLines` and `unfocusedLinesOpacity` to the `CodeBlock` component to control focusing a set of lines and dimming the other lines.
+Adds `focusedLines` and `unfocusedLinesOpacity` props to the `CodeBlock` component to control focusing a set of lines and dimming the other lines. It uses an image mask to dim out the lines which can be controlled using `unfocusedLinesOpacity`:
+
+````mdx
+```tsx focusedLines="3-4"
+const a = 1
+const b = 2
+const result = a + b
+console.log(result) // 3
+```
+````
+
+```tsx
+<CodeBlock
+  value={`const a = 1;\nconst b = 2;\n\nconst add = a + b\nconst subtract = a - b`}
+  focusedLines="2, 4"
+/>
+```

--- a/.changeset/witty-jars-drive.md
+++ b/.changeset/witty-jars-drive.md
@@ -1,0 +1,5 @@
+---
+"mdxts": minor
+---
+
+Adds `focusedLines` and `unfocusedLinesOpacity` to the `CodeBlock` component to control focusing a set of lines and dimming the other lines.

--- a/packages/mdxts/src/components/CodeBlock/CodeBlock.examples.tsx
+++ b/packages/mdxts/src/components/CodeBlock/CodeBlock.examples.tsx
@@ -43,9 +43,30 @@ export function LineNumbering() {
 export function LineHighlighting() {
   return (
     <CodeBlock
-      filename="line-highlights.ts"
+      filename="line-highlight.ts"
       value={`const a = 1;\nconst b = 2;\n\nconst add = a + b\nconst subtract = a - b`}
-      lineHighlights="1-2, 4"
+      lineHighlights="2, 4"
+    />
+  )
+}
+
+export function LineFocusing() {
+  return (
+    <CodeBlock
+      filename="line-focus.ts"
+      value={`const a = 1;\nconst b = 2;\n\nconst add = a + b\nconst subtract = a - b`}
+      focusedLines="2, 4"
+    />
+  )
+}
+
+export function LineHighlightAndFocus() {
+  return (
+    <CodeBlock
+      filename="line-highlight-and-focus.ts"
+      value={`const a = 1;\nconst b = 2;\n\nconst add = a + b\nconst subtract = a - b`}
+      lineHighlights="2, 4"
+      focusedLines="2, 4"
     />
   )
 }

--- a/packages/mdxts/src/components/CodeBlock/Context.tsx
+++ b/packages/mdxts/src/components/CodeBlock/Context.tsx
@@ -2,11 +2,13 @@ import { CSSProperties } from 'react'
 import { createContext } from '../../utils/context'
 import type { getTokens } from './get-tokens'
 
-export const Context = createContext<{
+export type ContextValue = {
   value: string
   tokens: Awaited<ReturnType<typeof getTokens>>
   filenameLabel?: string
   sourcePath?: string | false
-  highlight?: string
+  lineHighlights?: string
   padding?: CSSProperties['padding']
-} | null>(null)
+} | null
+
+export const Context = createContext<ContextValue>(null)

--- a/packages/mdxts/src/components/CodeBlock/LineHighlights.tsx
+++ b/packages/mdxts/src/components/CodeBlock/LineHighlights.tsx
@@ -3,27 +3,8 @@ import React from 'react'
 import { getThemeColors } from '../../index'
 import { getContext } from '../../utils/context'
 import { Context } from './Context'
-
-export type HighlightBlock = {
-  start: number
-  end: number
-  height: number
-}
-
-/** Parses a string of comma separated line ranges into an array of highlight blocks. */
-export function getHighlights(ranges: string): HighlightBlock[] {
-  return ranges.split(',').map((range) => {
-    const [start, end] = range.split('-')
-    const parsedStart = parseInt(start, 10) - 1
-    const parsedEnd = end ? parseInt(end, 10) - 1 : parsedStart
-
-    return {
-      start: parsedStart,
-      end: parsedEnd,
-      height: parsedEnd - parsedStart + 1,
-    }
-  })
-}
+import type { HighlightBlock } from './utils'
+import { getHighlights } from './utils'
 
 /** Renders a highlight over a range of `CodeBlock` lines. */
 export async function LineHighlights({
@@ -42,7 +23,7 @@ export async function LineHighlights({
 }) {
   const context = getContext(Context)
   const theme = await getThemeColors()
-  const highlightRanges = highlightRangesProp || context?.highlight
+  const highlightRanges = highlightRangesProp || context?.lineHighlights
 
   if (!highlightRanges) {
     throw new Error(

--- a/packages/mdxts/src/components/CodeBlock/LineNumbers.tsx
+++ b/packages/mdxts/src/components/CodeBlock/LineNumbers.tsx
@@ -34,7 +34,7 @@ export async function LineNumbers({
   }
 
   const theme = await getThemeColors()
-  const highlightRanges = highlightRangesProp || context?.highlight
+  const highlightRanges = highlightRangesProp || context?.lineHighlights
   const shouldHighlightLine = calculateLinesToHighlight(highlightRanges)
 
   return (


### PR DESCRIPTION
This adds `focusedLines` and `unfocusedLinesOpacity` props to the `CodeBlock` component to control focusing a set of lines and dimming the other lines. It uses an image mask to dim out the lines which can be controlled using `unfocusedLinesOpacity`:

````mdx
```tsx focusedLines="3-4"
const a = 1
const b = 2
const result = a + b
console.log(result) // 3
```
````

```tsx
 <CodeBlock
  value={`const a = 1;\nconst b = 2;\n\nconst add = a + b\nconst subtract = a - b`}
  focusedLines="2, 4"
/>
```