### PR TITLE
fix: nested package exports

### DIFF
--- a/.changeset/long-badgers-grab.md
+++ b/.changeset/long-badgers-grab.md
@@ -1,0 +1,5 @@
+---
+"mdxts": patch
+---
+
+fix: detection of deeply nested package.json exports

--- a/packages/mdxts/src/utils/get-entry-source-files.ts
+++ b/packages/mdxts/src/utils/get-entry-source-files.ts
@@ -39,6 +39,14 @@ export function getEntrySourceFiles(
         exportPath = exportValue.import
 
 
+        /* 
+        This is required for cases with nested export statements like this:
+
+        "import": {
+				 "types": "./dist/es/tailwind.d.mts",
+				 "default": "./dist/es/tailwind.mjs"
+			  },
+        **/
         if(typeof exportValue.import === 'object') {
           exportPath = exportValue.import.default
         }

--- a/packages/mdxts/src/utils/get-entry-source-files.ts
+++ b/packages/mdxts/src/utils/get-entry-source-files.ts
@@ -37,6 +37,11 @@ export function getEntrySourceFiles(
 
       if (typeof exportValue === 'object') {
         exportPath = exportValue.import
+
+
+        if(typeof exportValue.import === 'object') {
+          exportPath = exportValue.import.default
+        }
       }
 
       const sourceFilePaths = extensionPatterns

--- a/packages/mdxts/src/utils/get-entry-source-files.ts
+++ b/packages/mdxts/src/utils/get-entry-source-files.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'path'
-import { Project, SourceFile } from 'ts-morph'
+import type { Project, SourceFile } from 'ts-morph'
 
 import { getPackageMetadata } from './get-package-metadata'
 import { getSharedDirectoryPath } from './get-shared-directory-path'
@@ -18,7 +18,7 @@ const extensionPatterns = [
 export function getEntrySourceFiles(
   project: Project,
   allPaths: string[],
-  sourceDirectory: string = 'src',
+  sourceDirectory = 'src',
   outputDirectory: string | string[] = 'dist'
 ): SourceFile[] {
   if (typeof outputDirectory === 'string') {
@@ -36,18 +36,20 @@ export function getEntrySourceFiles(
       let exportPath = exportValue
 
       if (typeof exportValue === 'object') {
-        exportPath = exportValue.import
-
+        // Could also not exist if it's cjs only for example
+        if (exportValue.import) {
+          exportPath = exportValue.import
+        }
 
         /* 
         This is required for cases with nested export statements like this:
 
         "import": {
-				 "types": "./dist/es/tailwind.d.mts",
-				 "default": "./dist/es/tailwind.mjs"
-			  },
+         "types": "./dist/es/tailwind.d.mts",
+         "default": "./dist/es/tailwind.mjs"
+        },
         **/
-        if(typeof exportValue.import === 'object') {
+        if (typeof exportValue.import === 'object') {
           exportPath = exportValue.import.default
         }
       }


### PR DESCRIPTION
I use deeply nested package exports and was running into an issue since that edge case wasn't included yet.

I added some code to handle cases like this, where we have deeply nested configuration per export type.

```ts
"exports": {
		"./tailwind": {
			"import": {
				"types": "./dist/es/tailwind.d.mts",
				"default": "./dist/es/tailwind.mjs"
			},
			"require": {
				"types": "./dist/cjs/tailwind.d.ts",
				"default": "./dist/cjs/tailwind.js"
			}
}
	