### PR TITLE
remove CodeBlock fixImports prop

### DIFF
--- a/.changeset/dirty-moons-heal.md
+++ b/.changeset/dirty-moons-heal.md
@@ -1,0 +1,5 @@
+---
+'mdxts': minor
+---
+
+Removes the `fixImports` prop from `CodeBlock`. This prop fixed imports specifically for situtations like examples that are located in a different project and used relative imports. However, examples should use the library import path instead of relative paths by configuring the `module` field in `tsconfig.json`. More info [here](https://x.com/remcohaszing/status/1794338155963064548).

--- a/packages/mdxts/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/mdxts/src/components/CodeBlock/CodeBlock.tsx
@@ -51,9 +51,6 @@ export type BaseCodeBlockProps = {
   /** Path to the source file on disk in development and the git provider source in production. */
   sourcePath?: string | false
 
-  /** Whether or not to attempt to fix broken imports. Useful for code using imports outside of the project. */
-  fixImports?: boolean
-
   /** Class names to apply to code block elements. Use the `children` prop for full control of styling. */
   className?: {
     container?: string
@@ -101,7 +98,6 @@ export async function CodeBlock({
   showErrors,
   showLineNumbers,
   showToolbar,
-  fixImports,
   sourcePath,
   ...props
 }: CodeBlockProps) {
@@ -121,7 +117,6 @@ export async function CodeBlock({
     filename,
     language,
     allowErrors,
-    fixImports,
     ...options,
   })
   const tokens = await getTokens(

--- a/packages/mdxts/src/components/CodeBlock/parse-source-text-metadata.ts
+++ b/packages/mdxts/src/components/CodeBlock/parse-source-text-metadata.ts
@@ -15,7 +15,6 @@ type BaseParseMetadataOptions = {
   filename?: string
   language?: Languages
   allowErrors?: boolean | string
-  fixImports?: boolean
 }
 
 export type ParseMetadataOptions = BaseParseMetadataOptions &
@@ -32,7 +31,6 @@ export async function parseSourceTextMetadata({
   filename: filenameProp,
   language,
   allowErrors = false,
-  fixImports,
   ...props
 }: ParseMetadataOptions) {
   let finalValue: string = ''
@@ -133,57 +131,7 @@ export async function parseSourceTextMetadata({
         overwrite: true,
       })
 
-      // Fixes incorrect imports by removing them and trying to resolve them.
-      // This is the case with examples loaded from outside the main project directory.
-      if (fixImports) {
-        const importErrorCode = 2307
-        const shouldEmitDiagnostics =
-          typeof allowErrors === 'string'
-            ? !allowErrors.includes(importErrorCode.toString())
-            : allowErrors === false
-
-        if (shouldEmitDiagnostics) {
-          // Identify and collect missing imports/types to try and resolve them.
-          // This is specifically the case for examples since they import files relative to the package.
-          const diagnostics = sourceFile.getPreEmitDiagnostics()
-
-          sourceFile
-            .getImportDeclarations()
-            .filter((importDeclaration) => {
-              return diagnostics.some((diagnostic) => {
-                const diagnosticStart = diagnostic.getStart()
-                if (diagnosticStart === undefined) {
-                  return false
-                }
-                return (
-                  diagnostic.getCode() === importErrorCode &&
-                  diagnosticStart >= importDeclaration.getStart() &&
-                  diagnosticStart <= importDeclaration.getEnd()
-                )
-              })
-            })
-            .forEach((importDeclaration) => {
-              importDeclaration.remove()
-            })
-        }
-
-        // attempt to fix the removed imports and any other missing imports
-        sourceFile.fixMissingImports()
-
-        const importDeclarations = sourceFile.getImportDeclarations()
-
-        if (shouldEmitDiagnostics) {
-          // remap relative module specifiers to package imports if possible
-          // e.g. `import { getTheme } from '../../mdxts/src/components'` -> `import { getTheme } from 'mdxts/components'`
-          importDeclarations.forEach((importDeclaration) => {
-            if (importDeclaration.isModuleSpecifierRelative()) {
-              const importSpecifier =
-                getPathRelativeToPackage(importDeclaration)
-              importDeclaration.setModuleSpecifier(importSpecifier)
-            }
-          })
-        }
-      } else if (jsxOnly) {
+      if (jsxOnly) {
         // Since JSX only code blocks don't have imports, attempt to fix them.
         sourceFile.fixMissingImports()
       }

--- a/packages/mdxts/src/components/GitProvider.examples.tsx
+++ b/packages/mdxts/src/components/GitProvider.examples.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { GitProviderLink, GitProviderLogo } from './GitProvider'
+import { GitProviderLink, GitProviderLogo } from 'mdxts/components'
 
 export function Icon() {
   return <GitProviderLink />

--- a/site/app/examples/[...example]/page.tsx
+++ b/site/app/examples/[...example]/page.tsx
@@ -172,7 +172,6 @@ export default async function Page({
         }}
       >
         <CodeBlock
-          fixImports
           showLineNumbers
           value={example.sourceText}
           language="tsx"


### PR DESCRIPTION
Removes the `fixImports` prop from `CodeBlock`. This prop fixed imports specifically for situations like examples that are located in a different project and used relative imports. However, this can be extremely slow to calculate in large codebases due to the constant AST traversals from ts-morph. Examples should [use the library import path](https://github.com/souporserious/mdxts/commit/b6c22466ced5e471ecd7411b796f0e305559eb72) instead of relative paths by configuring the `module` field in `tsconfig.json`. More info [here](https://x.com/remcohaszing/status/1794338155963064548).
