### PR TITLE
add CopyButton component

### DIFF
--- a/.changeset/gentle-games-play.md
+++ b/.changeset/gentle-games-play.md
@@ -1,0 +1,5 @@
+---
+'mdxts': minor
+---
+
+Adds `CopyButton` to be used with custom `CodeBlock` components.

--- a/packages/mdxts/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/mdxts/src/components/CodeBlock/CodeBlock.tsx
@@ -8,6 +8,7 @@ import type { Languages } from './get-tokens'
 import { getTokens } from './get-tokens'
 import type { ContextValue } from './Context'
 import { Context } from './Context'
+import { CopyButtonContextProvider } from './contexts'
 import { LineNumbers } from './LineNumbers'
 import { Pre } from './Pre'
 import { Toolbar } from './Toolbar'
@@ -138,7 +139,13 @@ export async function CodeBlock({
   } satisfies ContextValue
 
   if ('children' in props) {
-    return <Context value={contextValue}>{props.children}</Context>
+    return (
+      <Context value={contextValue}>
+        <CopyButtonContextProvider value={metadata.value}>
+          {props.children}
+        </CopyButtonContextProvider>
+      </Context>
+    )
   }
 
   const theme = await getThemeColors()
@@ -274,8 +281,7 @@ export async function CodeBlock({
           )}
           {allowCopy !== false && !shouldRenderToolbar ? (
             <CopyButton
-              value={metadata.value}
-              style={{
+              css={{
                 placeSelf: 'start end',
                 gridColumn: showLineNumbers ? 2 : 1,
                 gridRow: '1 / -1',
@@ -287,6 +293,7 @@ export async function CodeBlock({
                 color: theme.activityBar.foreground,
                 borderRadius: 5,
               }}
+              value={metadata.value}
             />
           ) : null}
         </Pre>

--- a/packages/mdxts/src/components/CodeBlock/CopyButton.tsx
+++ b/packages/mdxts/src/components/CodeBlock/CopyButton.tsx
@@ -1,21 +1,45 @@
 'use client'
 import React, { useContext, useState } from 'react'
+import { css, type CSSProp } from 'restyle'
 
 import { PreActiveContext } from './Pre'
+import { CopyButtonContext } from './contexts'
 
-/**
- * Copies a value to the user's clipboard.
- * @internal
- */
+/** Copies a value to the user's clipboard. */
 export function CopyButton({
-  value,
-  style,
+  value: valueProp,
+  css: cssProp,
+  className,
   ...props
 }: {
-  value: string
+  value?: string
+  css?: CSSProp
 } & React.ComponentProps<'button'>) {
+  const contextValue = useContext(CopyButtonContext)
+  const value = valueProp || contextValue
+
+  if (!value) {
+    throw new Error(
+      '[mdxts] No value was provided to <CopyButton />. Use the `value` prop or use <CopyButton /> within a <CodeBlock /> component.'
+    )
+  }
+
   const preActive = useContext(PreActiveContext)
   const [state, setState] = useState<'idle' | 'not-allowed' | 'copied'>('idle')
+  const [classNames, styleElements] = css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '1lh',
+    height: '1lh',
+    fontSize: 'inherit',
+    lineHeight: 'inherit',
+    padding: 0,
+    border: 0,
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+    ...cssProp,
+  })
 
   if (state === 'idle' && preActive === false) {
     return null
@@ -26,7 +50,7 @@ export function CopyButton({
       title="Copy code to clipboard"
       onClick={() => {
         navigator.clipboard
-          .writeText(value)
+          .writeText(value!)
           .then(() => {
             setState('copied')
           })
@@ -37,20 +61,7 @@ export function CopyButton({
             setTimeout(() => setState('idle'), 1000)
           })
       }}
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '1lh',
-        height: '1lh',
-        fontSize: 'inherit',
-        lineHeight: 'inherit',
-        padding: 0,
-        border: 0,
-        backgroundColor: 'transparent',
-        cursor: 'pointer',
-        ...style,
-      }}
+      className={className ? `${className} ${classNames}` : classNames}
       {...props}
     >
       <svg
@@ -105,6 +116,7 @@ export function CopyButton({
           />
         ) : null}
       </svg>
+      {styleElements}
     </button>
   )
 }

--- a/packages/mdxts/src/components/CodeBlock/contexts.tsx
+++ b/packages/mdxts/src/components/CodeBlock/contexts.tsx
@@ -1,0 +1,18 @@
+'use client'
+import React, { createContext } from 'react'
+
+export const CopyButtonContext = createContext<string | null>(null)
+
+export function CopyButtonContextProvider({
+  value,
+  children,
+}: {
+  value: string
+  children: React.ReactNode
+}) {
+  return (
+    <CopyButtonContext.Provider value={value}>
+      {children}
+    </CopyButtonContext.Provider>
+  )
+}

--- a/packages/mdxts/src/components/CodeBlock/index.ts
+++ b/packages/mdxts/src/components/CodeBlock/index.ts
@@ -3,6 +3,7 @@ export {
   type BaseCodeBlockProps,
   type CodeBlockProps,
 } from './CodeBlock'
+export { CopyButton } from './CopyButton'
 export { LineNumbers } from './LineNumbers'
 export { Tokens, type TokensProps } from './Tokens'
 export { Toolbar, type ToolbarProps } from './Toolbar'

--- a/packages/mdxts/src/components/index.ts
+++ b/packages/mdxts/src/components/index.ts
@@ -1,5 +1,6 @@
 export {
   CodeBlock,
+  CopyButton,
   LineNumbers,
   Tokens,
   Toolbar,


### PR DESCRIPTION
This exposes the previously internal `CopyButton` component for use within custom `CodeBlock` components.