### PR TITLE
fix: Pathname generation with same name

### DIFF
--- a/.changeset/yellow-hounds-tell.md
+++ b/.changeset/yellow-hounds-tell.md
@@ -1,0 +1,9 @@
+---
+'mdxts': patch
+---
+
+Fix pathname generation in case the `baseDirectory` exists multiple times in the `filePath`.
+
+Previously having a file path like `content/content_1/path/file.mdx` and using `content` as base directory results in an invalid pathname like `content-1path/file`.
+
+Now we get the correct path name like `/content-1/path/file`.

--- a/packages/mdxts/src/utils/file-path-to-pathname.test.ts
+++ b/packages/mdxts/src/utils/file-path-to-pathname.test.ts
@@ -86,4 +86,28 @@ describe('filePathToUrlPathname', () => {
       '/hooks/use-hover'
     )
   })
+
+  it('handles nested paths with the same name - content/', () => {
+    expect(
+      filePathToPathname(
+        'content/content_1/section_1/01.page-1.mdx',
+        'content/'
+      )
+    ).toBe('/content-1/section-1/page-1')
+  })
+
+  it('handles nested paths with the same name - content', () => {
+    expect(
+      filePathToPathname('content/content_1/section_1/01.page-1.mdx', 'content')
+    ).toBe('/content-1/section-1/page-1')
+  })
+
+  it('handles nested paths with the same name - src/content', () => {
+    expect(
+      filePathToPathname(
+        'src/content/content_1/section_1/01.page-1.mdx',
+        'src/content'
+      )
+    ).toBe('/content-1/section-1/page-1')
+  })
 })

--- a/packages/mdxts/src/utils/file-path-to-pathname.ts
+++ b/packages/mdxts/src/utils/file-path-to-pathname.ts
@@ -1,4 +1,4 @@
-import { join, resolve, posix } from 'node:path'
+import { join, posix, resolve } from 'node:path'
 import slugify from '@sindresorhus/slugify'
 
 /** Converts a file system path to a URL-friendly pathname. */
@@ -22,8 +22,9 @@ export function filePathToPathname(
     baseDirectory = resolve(process.cwd(), baseDirectory)
   }
 
-  const [baseDirectoryPath, baseFilePath] = baseDirectory
-    ? filePath.split(baseDirectory)
+  // if baseDirectory is defined, ensure that there is a trailing slash
+  let [baseDirectoryPath, baseFilePath] = baseDirectory
+    ? filePath.split(baseDirectory.replace(/\/$|$/, '/'))
     : ['', filePath]
 
   if (baseFilePath === undefined) {
@@ -31,6 +32,9 @@ export function filePathToPathname(
       `Cannot determine base path for file path "${filePath}" at base directory "${baseDirectory}".`
     )
   }
+
+  // ensure that there is a leading slash
+  baseFilePath = createPathame(baseFilePath)
 
   let parsedFilePath = baseFilePath
     // Remove leading separator "./"

--- a/packages/mdxts/src/utils/file-path-to-pathname.ts
+++ b/packages/mdxts/src/utils/file-path-to-pathname.ts
@@ -1,4 +1,4 @@
-import { join, posix, resolve } from 'node:path'
+import { join, resolve, posix } from 'node:path'
 import slugify from '@sindresorhus/slugify'
 
 /** Converts a file system path to a URL-friendly pathname. */


### PR DESCRIPTION
* Updated the `filePathToPathname` to ensure
  * There is a trailing slash in the `baseDirectory` before we run the `.split()`
  * There is a leading slash in the `baseFilePath` before we start the generation of `parsedFilePath`
* Added the missing tests

Fixes #148 

