### PR TITLE
refactor add-reading-time plugin

### DIFF
--- a/.changeset/dependency-free-reading-time.md
+++ b/.changeset/dependency-free-reading-time.md
@@ -1,0 +1,5 @@
+---
+'@renoun/mdx': patch
+---
+
+Replaces the `rehype-infer-reading-time-meta` dependency with a built-in utility for calculating the reading time.

--- a/apps/site/guides/01.mdx.mdx
+++ b/apps/site/guides/01.mdx.mdx
@@ -72,10 +72,6 @@ Strips out badges, which are often used in README files.
 
 Cleans up the document by removing unnecessary empty paragraphs which can be caused by packages like `remark-strip-badges`.
 
-#### [`rehype-infer-reading-time-meta`](https://www.npmjs.com/package/rehype-infer-reading-time-meta)
-
-Infers reading time metadata for MDX content.
-
 #### [`rehype-unwrap-images`](https://www.npmjs.com/package/rehype-unwrap-images)
 
 Ensures that images are not wrapped in paragraph tags.
@@ -186,7 +182,28 @@ export default function Page() {
 
 #### rehype `add-reading-time`
 
-Exports the reading time metadata added by `rehype-infer-reading-time-meta` as a `readingTime` variable.
+Exports an estimated reading time for MDX content as a `readingTime` value. It uses `Intl.Segmenter` for accurate, locale-aware word segmentation, `Intl.NumberFormat` for formatting the reading time, can optionally include code blocks, and accounts for images.
+
+<Note>
+
+`readingTime` is exported for MDX files only (not plain Markdown). When using the default `MDX` component from `renoun`, this plugin is included automatically. If you override `rehypePlugins`, re-add it to keep the export.
+
+</Note>
+
+Consuming the exported `readingTime` from an MDX file:
+
+```tsx allowErrors showErrors={false}
+import GettingStarted, { readingTime } from './docs/getting-started.mdx'
+
+export default function Page() {
+  return (
+    <>
+      <p>{readingTime} min read</p>
+      <GettingStarted />
+    </>
+  )
+}
+```
 
 ## Applying plugins
 

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -93,7 +93,9 @@
     "@types/react": "catalog:",
     "@types/unist": "3.0.3",
     "react": "catalog:",
-    "vfile": "6.0.3"
+    "rehype-parse": "9.0.1",
+    "vfile": "6.0.3",
+    "vfile-message": "4.0.3"
   },
   "dependencies": {
     "@mdx-js/mdx": "3.1.1",
@@ -102,7 +104,6 @@
     "hast-util-to-jsx-runtime": "2.3.6",
     "mdast-util-mdx": "3.0.0",
     "mdast-util-to-string": "4.0.0",
-    "rehype-infer-reading-time-meta": "2.0.0",
     "rehype-unwrap-images": "1.0.0",
     "remark-gfm": "4.0.1",
     "remark-github": "12.0.0",
@@ -113,7 +114,6 @@
     "unified": "catalog:",
     "unist-util-mdx-define": "1.1.2",
     "unist-util-visit": "5.0.0",
-    "unist-util-visit-parents": "6.0.1",
-    "vfile-message": "4.0.3"
+    "unist-util-visit-parents": "6.0.1"
   }
 }

--- a/packages/mdx/src/rehype/add-reading-time.test.ts
+++ b/packages/mdx/src/rehype/add-reading-time.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { unified } from 'unified'
+import rehypeParse from 'rehype-parse'
+import { VFile } from 'vfile'
+
+import addReadingTime, {
+  type InferReadingTimeOptions,
+} from './add-reading-time'
+
+function run(html: string, options?: InferReadingTimeOptions) {
+  const file = new VFile({ value: html, path: 'test.html' })
+  const processor = unified().use(rehypeParse, { fragment: true })
+  processor.use(addReadingTime, options)
+  const tree = processor.parse(file)
+  processor.runSync(tree, file)
+  return file
+}
+
+describe('rehype/add-reading-time', () => {
+  it('exports formatted string by default', () => {
+    const file = run('<p>Hello world this is a short test.</p>')
+    const meta = file.data as any
+    expect(typeof meta.meta.readingTime).toBe('string')
+    expect(meta.meta.readingTime).toMatch(/^[0-9]+(\.[0-9])?$/)
+  })
+
+  it('exports raw number when format=false', () => {
+    const file = run(
+      '<p>One two three four five six seven eight nine ten.</p>',
+      { format: false }
+    )
+    const meta = file.data as any
+    expect(typeof meta.meta.readingTime).toBe('number')
+  })
+
+  it('applies rounding and digits', () => {
+    const html = '<p>' + 'word '.repeat(300) + '</p>'
+    const file = run(html, {
+      rounding: 'nearest',
+      digits: 1,
+      format: false,
+    })
+    const meta = file.data as any
+    expect(typeof meta.meta.readingTime).toBe('number')
+    // should be a one-decimal-place number
+    const value = meta.meta.readingTime as number
+    expect(Number.isFinite(value)).toBe(true)
+    expect(Math.round(value * 10) / 10).toBeCloseTo(value, 5)
+  })
+
+  it('counts images (default) and alt text/figcaption', () => {
+    const html =
+      '<figure><img alt="Alt text"/><figcaption>Caption text</figcaption></figure>'
+    const fileA = run(html, { format: false })
+    const fileB = run(html, { countImages: false, format: false })
+    const a = (fileA.data as any).meta.readingTime as number
+    const b = (fileB.data as any).meta.readingTime as number
+    expect(a).toBeGreaterThanOrEqual(b)
+  })
+
+  it('includeCode=false excludes code contribution', () => {
+    const html = '<pre><code>' + 'code '.repeat(300) + '</code></pre>'
+    const fileSkip = run(html, { includeCode: false, format: false })
+    const fileSlow = run(html, { includeCode: 'slow', format: false })
+    const a = (fileSkip.data as any).meta.readingTime as number
+    const b = (fileSlow.data as any).meta.readingTime as number
+    expect(a).toBeLessThanOrEqual(b)
+  })
+})

--- a/packages/mdx/src/rehype/add-reading-time.ts
+++ b/packages/mdx/src/rehype/add-reading-time.ts
@@ -1,9 +1,8 @@
 import type { Processor } from 'unified'
-import type { Root } from 'hast'
+import type { Element, Root, RootContent, Text } from 'hast'
 import type { VFile } from 'vfile'
 import { valueToEstree } from 'estree-util-value-to-estree'
 import { define } from 'unist-util-mdx-define'
-import rehypeInferReadingTimeMeta from 'rehype-infer-reading-time-meta'
 
 declare module 'unified' {
   interface Data {
@@ -12,40 +11,108 @@ declare module 'unified' {
 }
 
 /**
+ * Configuration for the reading time inference.
+ */
+export interface InferReadingTimeOptions {
+  /**
+   * The age or range of ages representing when your target audience typically finishes school.
+   * Single number or a 2-element array; null = use defaults.
+   */
+  age?: [number, number] | [number] | number | null
+
+  /**
+   * BCP-47 locale for word segmentation (Intl.Segmenter). Defaults to 'en'.
+   */
+  locale?: string
+
+  /**
+   * Count code blocks? false = exclude; 'slow' = include at half WPM; true = include at normal WPM.
+   * Default: 'slow'
+   */
+  includeCode?: boolean | 'slow'
+
+  /**
+   * Include alt text on <img> and text inside <figcaption> in the word count.
+   * Default: true
+   */
+  includeAltText?: boolean
+
+  /**
+   * Whether to add a per-image time bump (see imageSeconds).
+   * Default: true
+   */
+  countImages?: boolean
+
+  /**
+   * Seconds to add per image when countImages is true. Default: 12 seconds.
+   */
+  imageSeconds?: number
+
+  /**
+   * Rounding strategy for the exported minutes value. Default: 'nearest'.
+   * - 'none' returns the raw minutes value
+   * - 'nearest' rounds to the nearest value using `digits`
+   * - 'floor' floors using `digits`
+   * - 'ceil' ceils using `digits`
+   */
+  rounding?: 'none' | 'nearest' | 'floor' | 'ceil'
+
+  /**
+   * Number of fractional digits to keep when rounding (see `rounding`). Default: 1.
+   */
+  digits?: number
+
+  /**
+   * Whether to export a formatted string using Intl.NumberFormat (using `locale` and `digits`).
+   * Defaults to `true`. When `false`, exports a raw number.
+   */
+  format?: boolean
+}
+
+/**
  * Estimated reading time in minutes.
- *
+ * May be a number or a range tuple when an age range is provided.
  * The result is not rounded so it’s possible to retrieve estimated seconds from it.
  */
-export type MDXReadingTime = number
+export type MDXReadingTime = number | string
 
 /** Exports the reading time as a variable. */
 export default function addReadingTime(
   this: Processor,
   {
-    age = [18, 20],
-  }: {
-    /**
-     * The age or range of ages representing when your target audience typically finishes school.
-     *
-     * This parameter adjusts the reading time estimation based on the educational level of your readers.
-     * Provide a single number (e.g. `18` for high school graduates or `21` for college graduates)
-     * to indicate a specific graduation age.
-     *
-     * Alternatively, supply an array with lower and upper ages. For example, `[18, 21]` would
-     * cover both high school and college graduates.
-     *
-     * Setting to `null` will fall back to the default reading time assumptions.
-     */
-    age?: [number, number] | [number] | number | null
-  } = {}
+    age = defaultAge,
+    locale = 'en',
+    includeCode = 'slow',
+    includeAltText = true,
+    countImages = true,
+    imageSeconds = 12,
+    rounding = 'nearest',
+    digits = 1,
+    format = true,
+  }: InferReadingTimeOptions = {}
 ) {
-  const inferReadingTimeMeta = rehypeInferReadingTimeMeta({ age })
+  const addMeta = inferReadingTimeMeta({
+    age,
+    locale,
+    includeCode,
+    includeAltText,
+    countImages,
+    imageSeconds,
+    rounding,
+    digits,
+    format,
+  })
   const isMarkdown = this.data('isMarkdown') === true
 
   return function (tree: Root, file: VFile) {
-    inferReadingTimeMeta(tree, file)
+    addMeta(tree, file)
 
-    const readingTime = file.data.meta?.readingTime
+    const meta = (
+      file.data as {
+        meta?: { readingTime?: unknown }
+      }
+    ).meta
+    const readingTime = meta?.readingTime as MDXReadingTime | undefined
 
     if (!readingTime || isMarkdown) {
       return
@@ -54,5 +121,353 @@ export default function addReadingTime(
     define(tree, file, {
       readingTime: valueToEstree(readingTime),
     })
+  }
+}
+
+type ReadingTimeResult =
+  | [lowEstimate: number, highEstimate: number]
+  | [estimate: number]
+  | number
+
+const defaultAge: [number, number] = [18, 20]
+const firstGradeAge = 5
+const graduationAge = 22
+const addedWpmPerGrade = 14
+const reasonableWpm = 228
+const reasonableWpmMax = 340
+const baseWpm = reasonableWpm - (18 - firstGradeAge) * addedWpmPerGrade
+const precision = 1e6
+
+export function inferReadingTimeMeta({
+  age = defaultAge,
+  locale = 'en',
+  includeCode = 'slow',
+  includeAltText = true,
+  countImages = true,
+  imageSeconds = 12,
+  rounding = 'nearest',
+  digits = 1,
+  format = true,
+}: InferReadingTimeOptions = {}) {
+  return function (tree: Root, file: VFile) {
+    const readingTime = calculateReadingTime(tree, age, {
+      locale,
+      includeCode,
+      includeAltText,
+      countImages,
+      imageSeconds,
+    })
+
+    if (readingTime == null) {
+      return
+    }
+
+    const data = file.data as FileData
+    const matter = data.matter ?? {}
+    const meta = (data.meta ??= {} as FileMeta)
+
+    if ((matter as FileMeta).readingTime || meta.readingTime) {
+      return
+    }
+
+    const minutes = applyRounding(toMinutes(readingTime), rounding, digits)
+    if (format) {
+      meta.readingTime = formatMinutes(minutes, locale, digits)
+    } else {
+      meta.readingTime = minutes
+    }
+  }
+}
+
+type FileMeta = Record<string, unknown> & {
+  readingTime?: number | string
+}
+
+interface FileData {
+  matter?: Record<string, unknown>
+  meta?: FileMeta
+}
+
+type HastNode = Root | RootContent
+
+type InternalOptions = {
+  locale: string
+  includeCode: boolean | 'slow'
+  includeAltText: boolean
+  countImages: boolean
+  imageSeconds: number
+}
+
+function calculateReadingTime(
+  node: Root | Element,
+  age: InferReadingTimeOptions['age'],
+  opts: InternalOptions
+): ReadingTimeResult | null {
+  if (age == null) {
+    age = defaultAge.slice(0) as [number, number]
+  }
+
+  if (Array.isArray(age)) {
+    const estimates = age
+      .slice(0, 2)
+      .map((value) => calculateMinutes(node, value, opts))
+      .filter((value): value is number => value !== null)
+      .sort((a, b) => a - b)
+
+    if (estimates.length === 0) return null
+    return (
+      estimates.length === 1 ? [estimates[0]] : estimates
+    ) as ReadingTimeResult
+  }
+
+  const minutes = calculateMinutes(node, age, opts)
+  return minutes === null ? null : minutes
+}
+
+function calculateMinutes(
+  node: Root | Element,
+  age: number,
+  opts: InternalOptions
+): number | null {
+  const targetAge = clamp(Math.round(age), firstGradeAge, graduationAge)
+
+  const wpm = clamp(
+    baseWpm + (targetAge - firstGradeAge) * addedWpmPerGrade,
+    baseWpm,
+    reasonableWpmMax
+  )
+  if (wpm <= 0) return null
+
+  // Code WPM policy
+  const codeWpm =
+    opts.includeCode === 'slow' ? Math.max(1, Math.round(wpm / 2)) : wpm
+
+  // Analyze the tree once: get proseWords, codeWords, imageCount
+  const analysis = analyzeNode(node as HastNode, {
+    locale: opts.locale,
+    includeCode: opts.includeCode,
+    includeAltText: opts.includeAltText,
+  })
+
+  const proseMinutes = analysis.proseWords / wpm
+  const codeMinutes = opts.includeCode ? analysis.codeWords / codeWpm : 0
+
+  const imageMinutes =
+    opts.countImages && opts.imageSeconds > 0
+      ? (analysis.imageCount * opts.imageSeconds) / 60
+      : 0
+
+  const minutes = proseMinutes + codeMinutes + imageMinutes
+  return Math.round(minutes * precision) / precision
+}
+
+/** Types we always skip (MDX/ESM/comments). */
+const SKIP_TYPES = new Set<string>([
+  'comment',
+  'mdxTextExpression',
+  'mdxFlowExpression',
+  'mdxjsEsm',
+])
+
+/** Tags we always skip entirely. */
+const SKIP_TAGS_ALWAYS = new Set<string>([
+  'script',
+  'style',
+  'svg',
+  'math',
+  'noscript',
+])
+
+/** Code tags we *optionally* skip (based on includeCode). */
+const CODE_TAGS = new Set<string>(['pre', 'code'])
+
+type AnalyzeOptions = {
+  locale: string
+  includeCode: boolean | 'slow'
+  includeAltText: boolean
+}
+
+type Analysis = {
+  proseWords: number
+  codeWords: number
+  imageCount: number
+}
+
+/**
+ * Walks the HAST and returns word counts (prose vs code) and image count.
+ * - Skips MDX/ESM/comment nodes.
+ * - Skips script/style/svg/math/noscript entirely.
+ * - For code/pre: either skip, count as code, or include as prose depending on includeCode.
+ * - Includes alt text and figcaptions when enabled.
+ */
+function analyzeNode(node: HastNode, options: AnalyzeOptions): Analysis {
+  let proseWords = 0
+  let codeWords = 0
+  let imageCount = 0
+
+  function visit(node: HastNode, parentTag?: string) {
+    if (!node) return
+
+    // Text node — count directly as prose (unless parent is code/pre and we're treating as code)
+    if ((node as Text).type === 'text') {
+      const text = String((node as Text).value || '')
+      if (!text.trim()) return
+
+      const isCodeParent = parentTag ? CODE_TAGS.has(parentTag) : false
+
+      const words = countWords(text, options.locale)
+      if (isCodeParent) {
+        if (options.includeCode) codeWords += words
+      } else {
+        proseWords += words
+      }
+      return
+    }
+
+    // Skip certain node types entirely
+    if ('type' in node && SKIP_TYPES.has(node.type)) {
+      return
+    }
+
+    // Element branch
+    if (node.type === 'element') {
+      const element = node as Element
+      const tag = (element.tagName || '').toLowerCase()
+
+      // Always-skip tags
+      if (SKIP_TAGS_ALWAYS.has(tag)) return
+
+      // Image counting
+      if (tag === 'img' || tag === 'picture' || tag === 'figure') {
+        imageCount += 1
+      }
+
+      // Optionally include alt/figcaption text
+      if (options.includeAltText) {
+        if (tag === 'img') {
+          const alt = element.properties?.alt
+          if (typeof alt === 'string' && alt.trim()) {
+            proseWords += countWords(alt, options.locale)
+          }
+        }
+        if (tag === 'figure' && Array.isArray(element.children)) {
+          const caption = element.children.find(
+            (child: any) =>
+              child &&
+              typeof child.tagName === 'string' &&
+              child.tagName.toLowerCase() === 'figcaption'
+          )
+          if (caption) {
+            // Walk the figcaption subtree as normal prose
+            visit(caption, 'figcaption')
+          }
+        }
+      }
+
+      // Code policy
+      const isCodeTag = CODE_TAGS.has(tag)
+      if (isCodeTag && options.includeCode === false) {
+        // Skip code content entirely
+        return
+      }
+
+      // Recurse to children
+      if (Array.isArray(element.children)) {
+        for (const child of element.children) {
+          visit(child as HastNode, tag)
+        }
+      }
+      return
+    }
+
+    // Nodes with raw string "value" (e.g., raw/unknown) — ignore by default
+    if ('value' in node && typeof node.value === 'string') {
+      return
+    }
+
+    // Generic children traversal
+    if ('children' in node && Array.isArray(node.children)) {
+      for (const child of node.children as HastNode[]) {
+        visit(child, parentTag)
+      }
+    }
+  }
+
+  visit(node, undefined)
+
+  return { proseWords, codeWords, imageCount }
+}
+
+/**
+ * Unicode-aware word counting using Intl.Segmenter.
+ * Counts only segments with isWordLike === true.
+ */
+function countWords(value: string, locale: string): number {
+  const text = value.trim()
+  if (!text) {
+    return 0
+  }
+  const segmenter = new Intl.Segmenter(locale, { granularity: 'word' })
+  let count = 0
+  for (const { isWordLike } of segmenter.segment(text) as Iterable<{
+    isWordLike: boolean
+  }>) {
+    if (isWordLike) {
+      count++
+    }
+  }
+  return count
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+/**
+ * Normalize a reading time result (number or tuple) to a single minutes value.
+ * For ranges, this returns the average of the provided bounds.
+ */
+function toMinutes(result: ReadingTimeResult): number {
+  if (typeof result === 'number') {
+    return result
+  }
+  if (Array.isArray(result)) {
+    if (result.length === 1) {
+      return result[0]
+    }
+    const [low, high] = result
+    return (low + high) / 2
+  }
+  return 0
+}
+
+function applyRounding(
+  value: number,
+  mode: 'none' | 'nearest' | 'floor' | 'ceil',
+  digits: number
+): number {
+  if (!isFinite(value)) {
+    return 0
+  }
+  if (mode === 'none') {
+    return value
+  }
+  const factor = Math.pow(10, Math.max(0, Math.floor(digits)))
+  if (mode === 'nearest') {
+    return Math.round(value * factor) / factor
+  }
+  if (mode === 'floor') {
+    return Math.floor(value * factor) / factor
+  }
+  return Math.ceil(value * factor) / factor
+}
+
+function formatMinutes(value: number, locale: string, digits: number): string {
+  try {
+    return new Intl.NumberFormat(locale, {
+      maximumFractionDigits: Math.max(0, Math.floor(digits)),
+    }).format(value)
+  } catch {
+    return value.toFixed(Math.max(0, Math.floor(digits)))
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,9 +364,6 @@ importers:
       mdast-util-to-string:
         specifier: 4.0.0
         version: 4.0.0
-      rehype-infer-reading-time-meta:
-        specifier: 2.0.0
-        version: 2.0.0
       rehype-unwrap-images:
         specifier: 1.0.0
         version: 1.0.0
@@ -400,9 +397,6 @@ importers:
       unist-util-visit-parents:
         specifier: 6.0.1
         version: 6.0.1
-      vfile-message:
-        specifier: 4.0.3
-        version: 4.0.3
     devDependencies:
       '@types/estree':
         specifier: 1.0.8
@@ -422,9 +416,15 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.0
+      rehype-parse:
+        specifier: 9.0.1
+        version: 9.0.1
       vfile:
         specifier: 6.0.3
         version: 6.0.3
+      vfile-message:
+        specifier: 4.0.3
+        version: 4.0.3
 
   packages/renoun:
     dependencies:
@@ -2310,9 +2310,6 @@ packages:
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
-  array-iterate@1.1.4:
-    resolution: {integrity: sha512-sNRaPGh9nnmdC8Zf+pT3UqP8rnWj5Hf9wiFGsX3wUQ2yVSIhO2ShFwCoceIPpB41QF6i2OEmrHmCo36xronCVA==}
-
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
@@ -2328,12 +2325,6 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
-  automated-readability@1.0.5:
-    resolution: {integrity: sha512-N6mr0nUS0TB+SLHCrDYzLIdJQ1wklXNhsiKYh6tcrjDMlhjfz6BFGlDvngcpcBvZpko10jVjvF5XziJOxyA9Sg==}
-
-  bail@1.0.5:
-    resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
-
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -2344,18 +2335,12 @@ packages:
     resolution: {integrity: sha512-qsJ8/X+UypqxHXN75M7dF88jNK37dLBRW7LeUzCPz+TNs37G8cfWy9nWzS+LS//g600zrt2le9KuXt0rWfDz5Q==}
     hasBin: true
 
-  bcp-47-match@2.0.3:
-    resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
-
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
-
-  boolbase@1.0.0:
-    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
   boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
@@ -2496,9 +2481,6 @@ packages:
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
-  coleman-liau@1.0.5:
-    resolution: {integrity: sha512-g4N/LvbIoGP7cq9E8QGrUWkHnhm9DXP0g1+axHIQnmQq/MwwPbBx5dGxQ0GbY5+ojibsIo1Rg0XuYkF+JPr7sw==}
-
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -2526,9 +2508,6 @@ packages:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
 
-  compute-median@2.0.0:
-    resolution: {integrity: sha512-uuhQaBvZCqMDGprKVQohiTyrXLnYOim6ZoW0p/vZkbEQm2n8LRPUbplKPSF0+U8Ax0Ea0J4kSuMMkBnWkSn04g==}
-
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2544,9 +2523,6 @@ packages:
     resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
     engines: {node: '>=4'}
 
-  css-selector-parser@3.1.3:
-    resolution: {integrity: sha512-gJMigczVZqYAk0hPVzx/M4Hm1D9QOtqkdQk9005TNzDIUGzo5cnHEDiKUT7jGPximL/oYb+LIitcHFQ4aKupxg==}
-
   css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
@@ -2557,12 +2533,6 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-
-  dale-chall-formula@1.0.5:
-    resolution: {integrity: sha512-p7f37Bc6HkIUWDj/b/9r76qrXU7/yyR0lnp0Vmj0QjAG54KrFJbE8kVuPHdcKaCbwAFT8yNvCALMaajid/Mkfw==}
-
-  dale-chall@1.0.4:
-    resolution: {integrity: sha512-3Wp5GrsQVxw+KVXfZK9iA6W0jGnkq5uXXQ51Scofb92cbipkRvUZTaeQBr/6rlxdOezkjUGglV1euWIBOGCTRA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -2626,13 +2596,6 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  direction@2.0.1:
-    resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
-    hasBin: true
-
-  dom-walk@0.1.2:
-    resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
-
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -2655,6 +2618,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -2790,9 +2757,6 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
-  flesch@1.0.5:
-    resolution: {integrity: sha512-SE5X7jm4tp7sbKagLB0V9i0SrjWsFovus7db3E1nCyquy5249+Fyh+bBIK2crUuzX4maXn3Tu5bcMw8nF5oU8Q==}
-
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
@@ -2840,9 +2804,6 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  global@4.4.0:
-    resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
-
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
@@ -2852,9 +2813,6 @@ packages:
 
   grammex@3.1.10:
     resolution: {integrity: sha512-UCfMsV/sfqk4TN1+m5ehSOXuADyLUgSuwMI2vCVlbN/REoSmTl4eagswC9DzzVxtsKv7Yp2CmIJNn4fMk8PaQA==}
-
-  gunning-fog@1.0.6:
-    resolution: {integrity: sha512-yXkDi7mbWTPiITTztwhwXFMhXKnMviX/7kprz92BroMJbB/AgDATrHCRCtc87Ox024pQy2kMCihsm7tPonvV6A==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2868,20 +2826,20 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
   hast-util-has-property@3.0.0:
     resolution: {integrity: sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==}
 
   hast-util-interactive@3.0.0:
     resolution: {integrity: sha512-9VFa3kP6AT40BNYcPmn3jpsG+1KPDF0rUFCrFVQDUsuUXZ3YLODm8UGV0tmYzFpcOIQXTAOi2ccS3ywlj2dQTA==}
 
-  hast-util-is-element@3.0.0:
-    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
-
-  hast-util-reading-time@2.0.0:
-    resolution: {integrity: sha512-K2uSOCGwzVXNbjEn5GD7xevp6viCHDo2S/QZEArsjuey2lKDoKhAyY3n/TtoiAwLYeN2EpqgPoDqzDEcKr5aTQ==}
-
-  hast-util-select@6.0.4:
-    resolution: {integrity: sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==}
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
@@ -2889,14 +2847,11 @@ packages:
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
-  hast-util-to-string@3.0.1:
-    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
-
-  hast-util-to-text@4.0.2:
-    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
-
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   human-id@4.1.2:
     resolution: {integrity: sha512-v/J+4Z/1eIJovEBdlV5TYj1IR+ZiohcYGRY+qN/oC9dAfKzVT023N/Bgw37hrKCoVRBvk3bqyzpr2PP5YeTMSg==}
@@ -2914,9 +2869,6 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
@@ -2931,10 +2883,6 @@ packages:
 
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
-
-  is-buffer@2.0.5:
-    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
-    engines: {node: '>=4'}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -2973,10 +2921,6 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-
-  is-plain-obj@2.1.0:
-    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
-    engines: {node: '>=8'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -3343,9 +3287,6 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  min-document@2.19.0:
-    resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
-
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
@@ -3407,27 +3348,15 @@ packages:
       sass:
         optional: true
 
-  nlcst-normalize@2.1.5:
-    resolution: {integrity: sha512-xSqTKv8IHIy3n/orD7wj81BZljLfbrTot0Pv64MYUnQUXfDbi1xDSpJR4qEmbFWyFoHsmivcOdgrK+o7ky3mcw==}
-
-  nlcst-to-string@2.0.4:
-    resolution: {integrity: sha512-3x3jwTd6UPG7vi5k4GEzvxJ5rDA7hVUIRNHPblKuMVP9Z3xmlsd9cgLcpAMkc5uPOBna82EeshROFhsPkbnTZg==}
-
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
 
   node-releases@2.0.23:
     resolution: {integrity: sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==}
 
-  normalize-strings@1.1.1:
-    resolution: {integrity: sha512-fARPRdTwmrQDLYhmeh7j/eZwrCP6WzxD6uKOdK/hT/uKACAE9AG2Bc2dgqOZLkfmmctHpfcJ9w3AQnfLgg3GYg==}
-
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
-
-  nth-check@2.1.1:
-    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   on-headers@1.1.0:
     resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
@@ -3480,17 +3409,14 @@ packages:
   package-manager-detector@1.4.0:
     resolution: {integrity: sha512-rRZ+pR1Usc+ND9M2NkmCvE/LYJS+8ORVV9X0KuNSY/gFsp7RBHJM/ADh9LYq4Vvfq6QkKrW6/weuh8SMEtN5gw==}
 
-  parse-english@4.2.0:
-    resolution: {integrity: sha512-jw5N6wZUZViIw3VLG/FUSeL3vDhfw5Q2g4E3nYC69Mm5ANbh9ZWd+eligQbeUoyObZM8neynTn3l14e09pjEWg==}
-
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
-  parse-latin@4.3.0:
-    resolution: {integrity: sha512-TYKL+K98dcAWoCw/Ac1yrPviU8Trk+/gmjQVaoWEFDZmVD4KRg6c/80xKqNNFQObo2mTONgF8trzAf2UTwKafw==}
-
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -3538,10 +3464,6 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  pluralize@8.0.0:
-    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
-    engines: {node: '>=4'}
-
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
@@ -3574,10 +3496,6 @@ packages:
   pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
-
-  process@0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -3633,9 +3551,6 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
-  readability-scores@1.0.8:
-    resolution: {integrity: sha512-q1off3rS3Ho4veJhybRgUC4cDYseJqkXbaSz02e7HSMqirBoMB6KS82PVnbyfWLsgTOJVJMOgW+sjJADBOk+1A==}
-
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
 
@@ -3666,8 +3581,8 @@ packages:
     resolution: {integrity: sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==}
     engines: {node: '>=0.10.0'}
 
-  rehype-infer-reading-time-meta@2.0.0:
-    resolution: {integrity: sha512-IEkK+g2HTHx42bfQiU1wZECxeYjkKTJTUonBcxG5qOJST6bTgMqtv9Cf1V2/WhEN4vBTlWTGaG/QQ2LygiG6rQ==}
+  rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
@@ -3732,9 +3647,6 @@ packages:
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=19.0.0'
-
-  retext-english@3.0.4:
-    resolution: {integrity: sha512-yr1PgaBDde+25aJXrnt3p1jvT8FVLVat2Bx8XeAWX13KXo8OT+3nWGU3HWxM4YFJvmfqvJYJZG2d7xxaO774gw==}
 
   retext-latin@4.0.0:
     resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
@@ -3844,9 +3756,6 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  smog-formula@1.0.5:
-    resolution: {integrity: sha512-ogE7LgeO/UeaEP1f1FPrQHwBWURWzb+VIQfw/1K3xR+uzI7o5uS9B5K6rw1+Eq+GtseAg3KGz2m49YylwnfCoQ==}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3865,12 +3774,6 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  spache-formula@1.0.5:
-    resolution: {integrity: sha512-eYX6hYxeFRZbkcpunMrxhKcGAydeT0hZ958Q20J/UA119EybMrU+KuiSSKNbCwR4D55Yk8J6APg16yuWGtjcDw==}
-
-  spache@1.1.5:
-    resolution: {integrity: sha512-fblcef79rv7R/pRogLcnt8pYEWc5oLJ8RS7hArT6kCHp5gaVPG8EVzy2FjLbpCclfu77E6GpuNdnP6muTe4YxQ==}
-
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -3886,10 +3789,6 @@ packages:
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
-
-  stemmer@1.0.5:
-    resolution: {integrity: sha512-SLq7annzSKRDStasOJJoftCSCzBCKmBmH38jC4fDtCunAqOzpTpIm9zmaHmwNJiZ8gLe9qpVdBVbEG2DC5dE2A==}
-    hasBin: true
 
   string-escape-regex@1.0.1:
     resolution: {integrity: sha512-cdSXOHSJ32K/T2dbj9t7rJwonujaOkaINpa1zsXT+PNFIv1zuPjtr0tXanCvUhN2bIu2IB0z/C7ksl+Qsy44nA==}
@@ -3981,10 +3880,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  syllable@4.1.0:
-    resolution: {integrity: sha512-KUiIxtFxV17EEKqLYCHDcwaYxudDTRhX34mfTVYWkWFDsmiNRz1ZumpP3v0lTqsVQs78y3dqlSxkEMRk/SCVYQ==}
-    hasBin: true
-
   tailwindcss-react-aria-components@2.0.1:
     resolution: {integrity: sha512-yTAfYv9BE/gKczS+b8UiFMqxnrEYKKNE6Y4vAWzGadkHGb4Yuawp0SHbZKkZJQgFvK0KjO3JpCq/0kzR5jJ9tw==}
     peerDependencies:
@@ -4074,9 +3969,6 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
-  trough@1.0.5:
-    resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
-
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
@@ -4140,29 +4032,14 @@ packages:
   undici-types@7.14.0:
     resolution: {integrity: sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==}
 
-  unherit@1.1.3:
-    resolution: {integrity: sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==}
-
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
-
-  unified@9.2.2:
-    resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
-
-  unist-util-find-after@5.0.0:
-    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
-
-  unist-util-is@4.1.0:
-    resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
 
   unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
 
   unist-util-mdx-define@1.1.2:
     resolution: {integrity: sha512-9ncH7i7TN5Xn7/tzX5bE3rXgz1X/u877gYVAUB3mLeTKYJmQHmqKTDBi6BTGXV7AeolBCI9ErcVsOt2qryoD0g==}
-
-  unist-util-modify-children@2.0.0:
-    resolution: {integrity: sha512-HGrj7JQo9DwZt8XFsX8UD4gGqOsIlCih9opG6Y+N11XqkBGKzHo8cvDi+MfQQgiZ7zXRUiQREYHhjOBHERTMdg==}
 
   unist-util-modify-children@4.0.0:
     resolution: {integrity: sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==}
@@ -4173,26 +4050,14 @@ packages:
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
 
-  unist-util-stringify-position@2.0.3:
-    resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
-
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
-
-  unist-util-visit-children@1.1.4:
-    resolution: {integrity: sha512-sA/nXwYRCQVRwZU2/tQWUqJ9JSFM1X3x7JIOsIgSzrFHcfVt6NkzDtKzyxg2cZWkCwGF9CO8x4QNZRJRMK8FeQ==}
 
   unist-util-visit-children@3.0.0:
     resolution: {integrity: sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==}
 
-  unist-util-visit-parents@3.1.1:
-    resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
-
   unist-util-visit-parents@6.0.1:
     resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
-
-  unist-util-visit@2.0.3:
-    resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
@@ -4232,30 +4097,15 @@ packages:
       typescript:
         optional: true
 
-  validate.io-array@1.0.6:
-    resolution: {integrity: sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==}
-
-  validate.io-boolean@1.0.4:
-    resolution: {integrity: sha512-kQrj4QmbgBhOFg3T7B5WLxuQ5KFRy0D+hI53EojFUTVHQ+RXfy2VUjbpLa5hq+3c4OQb3qQGdF0VrlJHdKREgA==}
-
-  validate.io-function@1.0.2:
-    resolution: {integrity: sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ==}
-
-  validate.io-object@1.0.4:
-    resolution: {integrity: sha512-7F6MQSNoYmFm/zpvwg2fzDwQbZln9QRNWwmF6acm+QMkeluKVfXIw/D/Z/Sarg7yjmj1Go9WIjFXzmX86eCGYA==}
-
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vfile-message@2.0.4:
-    resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
-
-  vfile@4.2.1:
-    resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
@@ -4340,6 +4190,9 @@ packages:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
 
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
     engines: {node: '>=10.13.0'}
@@ -4375,10 +4228,6 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
-
-  xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -6620,8 +6469,6 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
-  array-iterate@1.1.4: {}
-
   array-iterate@2.0.1: {}
 
   array-union@2.1.0: {}
@@ -6630,10 +6477,6 @@ snapshots:
 
   astring@1.9.0: {}
 
-  automated-readability@1.0.5: {}
-
-  bail@1.0.5: {}
-
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
@@ -6641,15 +6484,11 @@ snapshots:
   baseline-browser-mapping@2.8.15:
     optional: true
 
-  bcp-47-match@2.0.3: {}
-
   before-after-hook@4.0.0: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
-
-  boolbase@1.0.0: {}
 
   boxen@7.0.0:
     dependencies:
@@ -6792,8 +6631,6 @@ snapshots:
 
   code-block-writer@13.0.3: {}
 
-  coleman-liau@1.0.5: {}
-
   collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
@@ -6825,13 +6662,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  compute-median@2.0.0:
-    dependencies:
-      validate.io-array: 1.0.6
-      validate.io-boolean: 1.0.4
-      validate.io-function: 1.0.2
-      validate.io-object: 1.0.4
-
   concat-map@0.0.1: {}
 
   content-disposition@0.5.2: {}
@@ -6844,8 +6674,6 @@ snapshots:
 
   css-color-keywords@1.0.0: {}
 
-  css-selector-parser@3.1.3: {}
-
   css-to-react-native@3.2.0:
     dependencies:
       camelize: 1.0.1
@@ -6855,10 +6683,6 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.1.3: {}
-
-  dale-chall-formula@1.0.5: {}
-
-  dale-chall@1.0.4: {}
 
   debug@2.6.9:
     dependencies:
@@ -6896,10 +6720,6 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  direction@2.0.1: {}
-
-  dom-walk@0.1.2: {}
-
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.233:
@@ -6920,6 +6740,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@6.0.1: {}
 
   environment@1.1.0: {}
 
@@ -7095,8 +6917,6 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  flesch@1.0.5: {}
-
   format@0.2.2: {}
 
   fs-extra@7.0.1:
@@ -7137,11 +6957,6 @@ snapshots:
   glob-to-regexp@0.4.1:
     optional: true
 
-  global@4.4.0:
-    dependencies:
-      min-document: 2.19.0
-      process: 0.11.10
-
   globby@11.1.0:
     dependencies:
       array-union: 2.1.0
@@ -7155,8 +6970,6 @@ snapshots:
 
   grammex@3.1.10: {}
 
-  gunning-fog@1.0.6: {}
-
   has-flag@4.0.0: {}
 
   has-flag@5.0.1: {}
@@ -7164,6 +6977,26 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
 
   hast-util-has-property@3.0.0:
     dependencies:
@@ -7174,34 +7007,9 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-has-property: 3.0.0
 
-  hast-util-is-element@3.0.0:
+  hast-util-parse-selector@4.0.0:
     dependencies:
       '@types/hast': 3.0.4
-
-  hast-util-reading-time@2.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      compute-median: 2.0.0
-      hast-util-to-text: 4.0.2
-      readability-scores: 1.0.8
-
-  hast-util-select@6.0.4:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      bcp-47-match: 2.0.3
-      comma-separated-tokens: 2.0.3
-      css-selector-parser: 3.1.3
-      devlop: 1.1.0
-      direction: 2.0.1
-      hast-util-has-property: 3.0.0
-      hast-util-to-string: 3.0.1
-      hast-util-whitespace: 3.0.0
-      nth-check: 2.1.1
-      property-information: 7.1.0
-      space-separated-tokens: 2.0.2
-      unist-util-visit: 5.0.0
-      zwitch: 2.0.4
 
   hast-util-to-estree@3.1.3:
     dependencies:
@@ -7244,20 +7052,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hast-util-to-string@3.0.1:
-    dependencies:
-      '@types/hast': 3.0.4
-
-  hast-util-to-text@4.0.2:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      hast-util-is-element: 3.0.0
-      unist-util-find-after: 5.0.0
-
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   human-id@4.1.2: {}
 
@@ -7268,8 +7073,6 @@ snapshots:
       safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
-
-  inherits@2.0.4: {}
 
   ini@1.3.8: {}
 
@@ -7288,8 +7091,6 @@ snapshots:
     dependencies:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
-
-  is-buffer@2.0.5: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -7314,8 +7115,6 @@ snapshots:
   is-module@1.0.0: {}
 
   is-number@7.0.0: {}
-
-  is-plain-obj@2.1.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -7919,10 +7718,6 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  min-document@2.19.0:
-    dependencies:
-      dom-walk: 0.1.2
-
   minimatch@10.0.3:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
@@ -7975,12 +7770,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nlcst-normalize@2.1.5:
-    dependencies:
-      nlcst-to-string: 2.0.4
-
-  nlcst-to-string@2.0.4: {}
-
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -7988,15 +7777,9 @@ snapshots:
   node-releases@2.0.23:
     optional: true
 
-  normalize-strings@1.1.1: {}
-
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-
-  nth-check@2.1.1:
-    dependencies:
-      boolbase: 1.0.0
 
   on-headers@1.1.0: {}
 
@@ -8052,13 +7835,6 @@ snapshots:
 
   package-manager-detector@1.4.0: {}
 
-  parse-english@4.2.0:
-    dependencies:
-      nlcst-to-string: 2.0.4
-      parse-latin: 4.3.0
-      unist-util-modify-children: 2.0.0
-      unist-util-visit-children: 1.1.4
-
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -8069,12 +7845,6 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
-  parse-latin@4.3.0:
-    dependencies:
-      nlcst-to-string: 2.0.4
-      unist-util-modify-children: 2.0.0
-      unist-util-visit-children: 1.1.4
-
   parse-latin@7.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -8083,6 +7853,10 @@ snapshots:
       unist-util-modify-children: 4.0.0
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-browserify@1.0.1: {}
 
@@ -8109,8 +7883,6 @@ snapshots:
   picomatch@4.0.3: {}
 
   pify@4.0.1: {}
-
-  pluralize@8.0.0: {}
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -8142,8 +7914,6 @@ snapshots:
   prettier@3.6.2: {}
 
   pretty-bytes@5.6.0: {}
-
-  process@0.11.10: {}
 
   property-information@7.1.0: {}
 
@@ -8292,26 +8062,6 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
-  readability-scores@1.0.8:
-    dependencies:
-      automated-readability: 1.0.5
-      coleman-liau: 1.0.5
-      dale-chall: 1.0.4
-      dale-chall-formula: 1.0.5
-      flesch: 1.0.5
-      global: 4.4.0
-      gunning-fog: 1.0.6
-      nlcst-normalize: 2.1.5
-      nlcst-to-string: 2.0.4
-      retext-english: 3.0.4
-      smog-formula: 1.0.5
-      spache: 1.1.5
-      spache-formula: 1.0.5
-      stemmer: 1.0.5
-      syllable: 4.1.0
-      unified: 9.2.2
-      unist-util-visit: 2.0.3
-
   recma-build-jsx@1.0.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -8360,13 +8110,11 @@ snapshots:
     dependencies:
       rc: 1.2.8
 
-  rehype-infer-reading-time-meta@2.0.0:
+  rehype-parse@9.0.1:
     dependencies:
       '@types/hast': 3.0.4
-      hast-util-reading-time: 2.0.0
-      hast-util-select: 6.0.4
+      hast-util-from-html: 2.0.3
       unified: 11.0.5
-      vfile: 6.0.3
 
   rehype-recma@1.0.0:
     dependencies:
@@ -8480,11 +8228,6 @@ snapshots:
   restyle@3.4.2(react@19.2.0):
     dependencies:
       react: 19.2.0
-
-  retext-english@3.0.4:
-    dependencies:
-      parse-english: 4.2.0
-      unherit: 1.1.3
 
   retext-latin@4.0.0:
     dependencies:
@@ -8669,8 +8412,6 @@ snapshots:
 
   slash@3.0.0: {}
 
-  smog-formula@1.0.5: {}
-
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -8685,10 +8426,6 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  spache-formula@1.0.5: {}
-
-  spache@1.1.5: {}
-
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8701,8 +8438,6 @@ snapshots:
   std-env@3.9.0: {}
 
   stdin-discarder@0.2.2: {}
-
-  stemmer@1.0.5: {}
 
   string-escape-regex@1.0.1: {}
 
@@ -8794,11 +8529,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  syllable@4.1.0:
-    dependencies:
-      normalize-strings: 1.1.1
-      pluralize: 8.0.0
-
   tailwindcss-react-aria-components@2.0.1(tailwindcss@4.1.14):
     dependencies:
       tailwindcss: 4.1.14
@@ -8873,8 +8603,6 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
-  trough@1.0.5: {}
-
   trough@2.2.0: {}
 
   ts-morph@27.0.0:
@@ -8927,11 +8655,6 @@ snapshots:
 
   undici-types@7.14.0: {}
 
-  unherit@1.1.3:
-    dependencies:
-      inherits: 2.0.4
-      xtend: 4.0.2
-
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -8941,23 +8664,6 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
-
-  unified@9.2.2:
-    dependencies:
-      '@types/unist': 2.0.11
-      bail: 1.0.5
-      extend: 3.0.2
-      is-buffer: 2.0.5
-      is-plain-obj: 2.1.0
-      trough: 1.0.5
-      vfile: 4.2.1
-
-  unist-util-find-after@5.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
-
-  unist-util-is@4.1.0: {}
 
   unist-util-is@6.0.0:
     dependencies:
@@ -8973,10 +8679,6 @@ snapshots:
       estree-walker: 3.0.3
       vfile: 6.0.3
 
-  unist-util-modify-children@2.0.0:
-    dependencies:
-      array-iterate: 1.1.4
-
   unist-util-modify-children@4.0.0:
     dependencies:
       '@types/unist': 3.0.3
@@ -8990,35 +8692,18 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  unist-util-stringify-position@2.0.3:
-    dependencies:
-      '@types/unist': 2.0.11
-
   unist-util-stringify-position@4.0.0:
     dependencies:
       '@types/unist': 3.0.3
-
-  unist-util-visit-children@1.1.4: {}
 
   unist-util-visit-children@3.0.0:
     dependencies:
       '@types/unist': 3.0.3
 
-  unist-util-visit-parents@3.1.1:
-    dependencies:
-      '@types/unist': 2.0.11
-      unist-util-is: 4.1.0
-
   unist-util-visit-parents@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
-
-  unist-util-visit@2.0.3:
-    dependencies:
-      '@types/unist': 2.0.11
-      unist-util-is: 4.1.0
-      unist-util-visit-parents: 3.1.1
 
   unist-util-visit@5.0.0:
     dependencies:
@@ -9056,34 +8741,17 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  validate.io-array@1.0.6: {}
-
-  validate.io-boolean@1.0.4: {}
-
-  validate.io-function@1.0.2: {}
-
-  validate.io-object@1.0.4:
-    dependencies:
-      validate.io-array: 1.0.6
-
   vary@1.1.2: {}
 
-  vfile-message@2.0.4:
+  vfile-location@5.0.3:
     dependencies:
-      '@types/unist': 2.0.11
-      unist-util-stringify-position: 2.0.3
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
 
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
-
-  vfile@4.2.1:
-    dependencies:
-      '@types/unist': 2.0.11
-      is-buffer: 2.0.5
-      unist-util-stringify-position: 2.0.3
-      vfile-message: 2.0.4
 
   vfile@6.0.3:
     dependencies:
@@ -9178,6 +8846,8 @@ snapshots:
       graceful-fs: 4.2.11
     optional: true
 
+  web-namespaces@2.0.1: {}
+
   webpack-sources@3.3.3:
     optional: true
 
@@ -9236,8 +8906,6 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
-
-  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
Replaces the `rehype-infer-reading-time-meta` dependency with a built-in utility for calculating the reading time.

The new built-in utility:

- Uses `Intl.Segmenter` for accurate, locale-aware word segmentation.
- Distinguishes prose vs code and images:
  - `includeCode`: false | 'slow' | true (defaults to 'slow')
  - `includeAltText`: include `<img alt>` and `<figcaption>` text (defaults to true)
  - `countImages` and `imageSeconds` to add per-image seconds (defaults to true and 12s)
- Adds configurable rounding of minutes:
  - `rounding` ('none' | 'nearest' | 'floor' | 'ceil')
  - `digits` (defaults to 'nearest' with 1 digit).
- Exports a single `readingTime` variable from MDX:
  - Formats string by default (using `Intl.NumberFormat` with the same `locale` and `digits`)
  - Sets `format: false` to export a raw numeric minutes value instead