### PR TITLE
fix vite builds

### DIFF
--- a/.changeset/fix-ts-morph-vite.md
+++ b/.changeset/fix-ts-morph-vite.md
@@ -1,0 +1,5 @@
+---
+'renoun': patch
+---
+
+Fixes `ts-morph` erroring in Vite builds by loading the package dynamically to resolve the CommonJS module at runtime.

--- a/packages/renoun/src/file-system/FileSystem.ts
+++ b/packages/renoun/src/file-system/FileSystem.ts
@@ -1,5 +1,5 @@
 import { Minimatch } from 'minimatch'
-import type { SyntaxKind, ts } from 'ts-morph'
+import type { SyntaxKind, ts } from '../utils/ts-morph.js'
 
 import {
   getFileExports,

--- a/packages/renoun/src/file-system/MemoryFileSystem.ts
+++ b/packages/renoun/src/file-system/MemoryFileSystem.ts
@@ -1,5 +1,5 @@
 import ignore from 'fast-ignore'
-import * as tsMorph from 'ts-morph'
+import { getTsMorph } from '../utils/ts-morph.js'
 
 import { createSourceFile, transpileSourceFile } from '../project/client.js'
 import type { ProjectOptions } from '../project/types.js'
@@ -7,6 +7,8 @@ import { isJavaScriptLikeExtension } from '../utils/is-javascript-like-extension
 import { joinPaths, normalizePath, normalizeSlashes } from '../utils/path.js'
 import { FileSystem } from './FileSystem.js'
 import type { DirectoryEntry } from './types.js'
+
+const tsMorph = getTsMorph()
 
 export type MemoryFileTextEntry = {
   kind: 'text'

--- a/packages/renoun/src/project/cache.ts
+++ b/packages/renoun/src/project/cache.ts
@@ -1,4 +1,4 @@
-import type { Project } from 'ts-morph'
+import type { Project } from '../utils/ts-morph.js'
 
 import { waitForRefreshingProjects } from './refresh.js'
 

--- a/packages/renoun/src/project/client.ts
+++ b/packages/renoun/src/project/client.ts
@@ -1,4 +1,4 @@
-import type { SyntaxKind } from 'ts-morph'
+import type { SyntaxKind } from '../utils/ts-morph.js'
 
 import type { ConfigurationOptions } from '../components/Config/types.js'
 import {

--- a/packages/renoun/src/project/get-printer.ts
+++ b/packages/renoun/src/project/get-printer.ts
@@ -1,5 +1,7 @@
-import type { Project, ts } from 'ts-morph'
-import * as tsMorph from 'ts-morph'
+import { getTsMorph } from '../utils/ts-morph.js'
+import type { Project, ts } from '../utils/ts-morph.js'
+
+const tsMorph = getTsMorph()
 
 const printerCache = new WeakMap<Project, ts.Printer>()
 const LineFeed = tsMorph.ts.NewLineKind.LineFeed

--- a/packages/renoun/src/project/get-project.ts
+++ b/packages/renoun/src/project/get-project.ts
@@ -1,4 +1,5 @@
-import { Project, ts } from 'ts-morph'
+import { getTsMorph } from '../utils/ts-morph.js'
+import type { Project as TsMorphProject, ts as TsMorphTS } from '../utils/ts-morph.js'
 import { join, dirname, extname, resolve } from 'node:path'
 import { existsSync, watch, statSync } from 'node:fs'
 import type { FSWatcher } from 'node:fs'
@@ -15,9 +16,11 @@ import {
 } from './refresh.js'
 import type { ProjectOptions } from './types.js'
 
-const projects = new Map<string, Project>()
+const { Project, ts } = getTsMorph()
+
+const projects = new Map<string, TsMorphProject>()
 const directoryWatchers = new Map<string, FSWatcher>()
-const directoryToProjects = new Map<string, Set<Project>>()
+const directoryToProjects = new Map<string, Set<TsMorphProject>>()
 
 const defaultCompilerOptions = {
   allowJs: true,
@@ -32,7 +35,7 @@ const defaultCompilerOptions = {
   module: ts.ModuleKind.ESNext,
   moduleDetection: ts.ModuleDetectionKind.Force,
   target: ts.ScriptTarget.ESNext,
-} satisfies ts.CompilerOptions
+} satisfies TsMorphTS.CompilerOptions
 
 /** Get the project associated with the provided options. */
 export function getProject(options?: ProjectOptions) {
@@ -161,7 +164,7 @@ export function getProject(options?: ProjectOptions) {
   return project
 }
 
-function refreshOrAddSourceFile(project: Project, filePath: string) {
+function refreshOrAddSourceFile(project: TsMorphProject, filePath: string) {
   const existingSourceFile = project.getSourceFile(filePath)
 
   if (!existingSourceFile) {
@@ -190,7 +193,7 @@ function createProjectDebugContext({
   projectOptions,
   cacheStatus,
 }: {
-  project: Project
+  project: TsMorphProject
   projectId: string
   projectDirectory: string
   projectOptions?: ProjectOptions

--- a/packages/renoun/src/project/refresh.ts
+++ b/packages/renoun/src/project/refresh.ts
@@ -1,4 +1,4 @@
-import type { FileSystemRefreshResult } from 'ts-morph'
+import type { FileSystemRefreshResult } from '../utils/ts-morph.js'
 import { EventEmitter } from 'node:events'
 
 const REFRESHING_COMPLETED = 'refreshing:completed'

--- a/packages/renoun/src/project/server.ts
+++ b/packages/renoun/src/project/server.ts
@@ -1,6 +1,7 @@
 import { watch } from 'node:fs'
 import { join } from 'node:path'
-import { SyntaxKind } from 'ts-morph'
+import { getTsMorph } from '../utils/ts-morph.js'
+import type { SyntaxKind as TsMorphSyntaxKind } from '../utils/ts-morph.js'
 
 import {
   createHighlighter,
@@ -28,6 +29,8 @@ import { transpileSourceFile as baseTranspileSourceFile } from '../utils/transpi
 import { WebSocketServer } from './rpc/server.js'
 import { getProject } from './get-project.js'
 import type { ProjectOptions } from './types.js'
+
+const { SyntaxKind } = getTsMorph()
 
 let currentHighlighter: Promise<Highlighter> | null = null
 
@@ -120,7 +123,7 @@ export async function createServer(options?: { port?: number }) {
     }: {
       filePath: string
       position: number
-      kind: SyntaxKind
+      kind: TsMorphSyntaxKind
       filter?: string
       projectOptions?: ProjectOptions
     }) {
@@ -192,7 +195,7 @@ export async function createServer(options?: { port?: number }) {
       name: string
       filePath: string
       position: number
-      kind: SyntaxKind
+      kind: TsMorphSyntaxKind
       projectOptions?: ProjectOptions
     }) {
       const project = getProject(projectOptions)
@@ -215,7 +218,7 @@ export async function createServer(options?: { port?: number }) {
     }: {
       filePath: string
       position: number
-      kind: SyntaxKind
+      kind: TsMorphSyntaxKind
       includeDependencies?: boolean
       projectOptions?: ProjectOptions
     }) {
@@ -244,7 +247,7 @@ export async function createServer(options?: { port?: number }) {
     }: {
       filePath: string
       position: number
-      kind: SyntaxKind
+      kind: TsMorphSyntaxKind
       projectOptions?: ProjectOptions
     }) {
       const project = getProject(projectOptions)

--- a/packages/renoun/src/project/types.ts
+++ b/packages/renoun/src/project/types.ts
@@ -1,4 +1,4 @@
-import type { ProjectOptions as TsMorphProjectOptions } from 'ts-morph'
+import type { ProjectOptions as TsMorphProjectOptions } from '../utils/ts-morph.js'
 
 import type { Themes } from '../grammars/index.js'
 

--- a/packages/renoun/src/utils/get-declaration-location.ts
+++ b/packages/renoun/src/utils/get-declaration-location.ts
@@ -1,4 +1,4 @@
-import type { Node, Project } from 'ts-morph'
+import type { Node, Project } from './ts-morph.js'
 
 /** The start and and position of the declaration in the file. */
 export type DeclarationPosition = {

--- a/packages/renoun/src/utils/get-diagnostic-message.test.ts
+++ b/packages/renoun/src/utils/get-diagnostic-message.test.ts
@@ -1,8 +1,10 @@
 import { describe, test, expect } from 'vitest'
-import { Project } from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
 import dedent from 'dedent'
 
 import { getDiagnosticMessageText } from './get-diagnostic-message.js'
+
+const { Project } = getTsMorph()
 
 describe('getDiagnosticMessageText', () => {
   const project = new Project()

--- a/packages/renoun/src/utils/get-diagnostic-message.ts
+++ b/packages/renoun/src/utils/get-diagnostic-message.ts
@@ -1,4 +1,4 @@
-import type { DiagnosticMessageChain } from 'ts-morph'
+import type { DiagnosticMessageChain } from './ts-morph.js'
 
 /** Parses a diagnostic message into a string. */
 export function getDiagnosticMessageText(

--- a/packages/renoun/src/utils/get-directory-source-file.test.ts
+++ b/packages/renoun/src/utils/get-directory-source-file.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from 'vitest'
-import { Project } from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+
+const { Project } = getTsMorph()
 
 import { getDirectorySourceFile } from './get-directory-source-file'
 

--- a/packages/renoun/src/utils/get-directory-source-file.ts
+++ b/packages/renoun/src/utils/get-directory-source-file.ts
@@ -1,4 +1,4 @@
-import type { Directory, SourceFile } from 'ts-morph'
+import type { Directory, SourceFile } from './ts-morph.js'
 
 const indexFileNames = [
   'js',

--- a/packages/renoun/src/utils/get-file-export-static-value.ts
+++ b/packages/renoun/src/utils/get-file-export-static-value.ts
@@ -1,5 +1,7 @@
-import type { Project } from 'ts-morph'
-import tsMorph from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+import type { Expression, Project, SyntaxKind } from './ts-morph.js'
+
+const tsMorph = getTsMorph()
 
 import { getFileExportDeclaration } from './get-file-exports.js'
 import {
@@ -12,7 +14,7 @@ import {
 export async function getFileExportStaticValue(
   filePath: string,
   position: number,
-  kind: tsMorph.SyntaxKind,
+  kind: SyntaxKind,
   project: Project
 ): Promise<LiteralExpressionValue> {
   let sourceFile = project.getSourceFile(filePath)
@@ -31,7 +33,7 @@ export async function getFileExportStaticValue(
     kind,
     project
   )
-  let expression: tsMorph.Expression | undefined
+  let expression: Expression | undefined
 
   if (tsMorph.Node.isVariableDeclaration(exportDeclaration)) {
     expression = exportDeclaration.getInitializer()

--- a/packages/renoun/src/utils/get-file-export-text.ts
+++ b/packages/renoun/src/utils/get-file-export-text.ts
@@ -1,10 +1,12 @@
-import type { Project } from 'ts-morph'
-import * as tsMorph from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+import type { Project, SyntaxKind } from './ts-morph.js'
 
 import { createProjectFileCache } from '../project/cache.js'
 import { getFileExportDeclaration } from './get-file-exports.js'
 import { getFileExportsText } from './get-file-exports-text.js'
 import { getRootDirectory } from './get-root-directory.js'
+
+const tsMorph = getTsMorph()
 
 /** Get a specific file export's text by identifier, optionally including its dependencies. */
 export async function getFileExportText({
@@ -16,7 +18,7 @@ export async function getFileExportText({
 }: {
   filePath: string
   position: number
-  kind: tsMorph.SyntaxKind
+  kind: SyntaxKind
   project: Project
   includeDependencies?: boolean
 }) {

--- a/packages/renoun/src/utils/get-file-exports-text.test.ts
+++ b/packages/renoun/src/utils/get-file-exports-text.test.ts
@@ -1,7 +1,9 @@
 import { describe, test, expect } from 'vitest'
-import { Project } from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
 
 import { getFileExportsText } from './get-file-exports-text.js'
+
+const { Project } = getTsMorph()
 
 const sourceFileText = `
 import * as React from 'react'

--- a/packages/renoun/src/utils/get-file-exports-text.ts
+++ b/packages/renoun/src/utils/get-file-exports-text.ts
@@ -1,13 +1,16 @@
+import { getTsMorph } from './ts-morph.js'
 import type {
   ImportDeclaration,
   Node,
   Project,
   SourceFile,
   SyntaxKind,
-} from 'ts-morph'
-import * as tsMorph from 'ts-morph'
+  ts,
+} from './ts-morph.js'
 
 import { getPrinter } from '../project/get-printer.js'
+
+const tsMorph = getTsMorph()
 
 interface DeclarationInfo {
   /** The symbol ID of the declaration */
@@ -408,7 +411,7 @@ function buildTextSnippet(
   usedLocals: Set<string>,
   sourceFile: SourceFile,
   declarationMap: Map<string, DeclarationInfo>,
-  printer: tsMorph.ts.Printer
+  printer: ts.Printer
 ): string {
   const usedImports = getUsedImports(usedLocals, declarationMap)
   const fileStatements = sourceFile.getStatements()
@@ -485,7 +488,7 @@ function stripLeadingJsDoc(text: string): string {
 function printFilteredImportStatement(
   declaration: ImportDeclaration,
   usedAliases: Set<string>,
-  printer: tsMorph.ts.Printer
+  printer: ts.Printer
 ): string | undefined {
   const ts = tsMorph.ts
   const { factory } = ts
@@ -545,17 +548,17 @@ function printFilteredImportStatement(
 
 /** Determine if a node has a specific modifier kind. */
 function hasModifier(
-  node: tsMorph.Node & { getModifiers?: () => tsMorph.Node[] },
-  kind: tsMorph.SyntaxKind
+  node: Node & { getModifiers?: () => Node[] },
+  kind: SyntaxKind
 ) {
   return node.getModifiers?.()?.some((modifier) => modifier.getKind() === kind)
 }
 
 /** Returns true if this is an anonymous default export (no name, export + default modifiers). */
 function isAnonymousDefaultExportStatement(
-  statement: tsMorph.Node & {
-    getModifiers?: () => tsMorph.Node[]
-    getNameNode?: () => tsMorph.Node | undefined
+  statement: Node & {
+    getModifiers?: () => Node[]
+    getNameNode?: () => Node | undefined
   }
 ) {
   // Must be function or class declarations for our current anonymous support.

--- a/packages/renoun/src/utils/get-file-exports.ts
+++ b/packages/renoun/src/utils/get-file-exports.ts
@@ -1,5 +1,7 @@
-import type { Node, Project } from 'ts-morph'
-import * as tsMorph from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+import type { Node, Project, SyntaxKind } from './ts-morph.js'
+
+const tsMorph = getTsMorph()
 
 import { getDebugLogger } from './debug.js'
 import { getDeclarationLocation } from './get-declaration-location.js'
@@ -9,7 +11,7 @@ export interface ModuleExport {
   name: string
   path: string
   position: number
-  kind: tsMorph.SyntaxKind
+  kind: SyntaxKind
 }
 
 const exportableKinds = new Set([
@@ -146,7 +148,7 @@ export function getFileExports(
 export function getFileExportDeclaration(
   filePath: string,
   position: number,
-  kind: tsMorph.SyntaxKind,
+  kind: SyntaxKind,
   project: Project
 ) {
   return getDebugLogger().trackOperation(
@@ -196,7 +198,7 @@ export function getFileExportDeclaration(
         kind: tsMorph.SyntaxKind[kind],
       },
     }
-  ) as tsMorph.Node
+  ) as Node
 }
 
 /** Returns metadata about a specific export of a file. */
@@ -204,7 +206,7 @@ export async function getFileExportMetadata(
   name: string,
   filePath: string,
   position: number,
-  kind: tsMorph.SyntaxKind,
+  kind: SyntaxKind,
   project: Project
 ) {
   return getDebugLogger().trackOperation(

--- a/packages/renoun/src/utils/get-initializer-value.test.ts
+++ b/packages/renoun/src/utils/get-initializer-value.test.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect } from 'vitest'
 import dedent from 'dedent'
-import { Project, SyntaxKind } from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+
+const { Project, SyntaxKind } = getTsMorph()
 
 import { getInitializerValue } from './get-initializer-value.js'
 

--- a/packages/renoun/src/utils/get-initializer-value.ts
+++ b/packages/renoun/src/utils/get-initializer-value.ts
@@ -1,3 +1,4 @@
+import { getTsMorph } from './ts-morph.js'
 import type {
   Expression,
   ParameterDeclaration,
@@ -6,8 +7,9 @@ import type {
   ObjectBindingPattern,
   PropertyDeclaration,
   PropertySignature,
-} from 'ts-morph'
-import tsMorph from 'ts-morph'
+} from './ts-morph.js'
+
+const tsMorph = getTsMorph()
 
 import {
   resolveLiteralExpression,

--- a/packages/renoun/src/utils/get-js-doc-metadata.test.ts
+++ b/packages/renoun/src/utils/get-js-doc-metadata.test.ts
@@ -1,7 +1,9 @@
 import { describe, test, expect } from 'vitest'
-import { Project } from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
 
 import { getJsDocMetadata } from './get-js-doc-metadata.js'
+
+const { Project } = getTsMorph()
 
 describe('getJsDocMetadata', () => {
   const project = new Project()

--- a/packages/renoun/src/utils/get-js-doc-metadata.ts
+++ b/packages/renoun/src/utils/get-js-doc-metadata.ts
@@ -1,5 +1,7 @@
-import type { Node } from 'ts-morph'
-import tsMorph from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+import type { Node } from './ts-morph.js'
+
+const tsMorph = getTsMorph()
 
 /** Gets the description and tags from a JSDoc comment for a node. */
 export function getJsDocMetadata(node: Node):

--- a/packages/renoun/src/utils/get-name-from-declaration.test.ts
+++ b/packages/renoun/src/utils/get-name-from-declaration.test.ts
@@ -1,7 +1,9 @@
 import { describe, test, expect } from 'vitest'
-import { Project } from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
 
 import { getNameFromDeclaration } from './get-name-from-declaration.js'
+
+const { Project } = getTsMorph()
 
 describe('getMainExportDeclaration', () => {
   const project = new Project()

--- a/packages/renoun/src/utils/get-name-from-declaration.ts
+++ b/packages/renoun/src/utils/get-name-from-declaration.ts
@@ -1,5 +1,7 @@
-import type { Node } from 'ts-morph'
-import tsMorph from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+import type { Node } from './ts-morph.js'
+
+const tsMorph = getTsMorph()
 
 /** Returns the name of a function, variable, class, or type alias declaration if applicable. */
 export function getNameFromDeclaration(declaration: Node): string | null {

--- a/packages/renoun/src/utils/get-source-files-order-map.test.ts
+++ b/packages/renoun/src/utils/get-source-files-order-map.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect, beforeEach } from 'vitest'
-import { Project, type Directory } from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+import type { Directory } from './ts-morph.js'
+
+const { Project } = getTsMorph()
 
 import { getSourceFilesOrderMap } from './get-source-files-order-map.js'
 

--- a/packages/renoun/src/utils/get-source-files-order-map.ts
+++ b/packages/renoun/src/utils/get-source-files-order-map.ts
@@ -1,4 +1,4 @@
-import type { Directory } from 'ts-morph'
+import type { Directory } from './ts-morph.js'
 
 /** Returns a map of source file paths to their sort order. */
 export function getSourceFilesOrderMap(

--- a/packages/renoun/src/utils/get-source-text-metadata.ts
+++ b/packages/renoun/src/utils/get-source-text-metadata.ts
@@ -1,5 +1,5 @@
 import { dirname, join, posix, isAbsolute } from 'node:path'
-import type { Project } from 'ts-morph'
+import type { Project } from './ts-morph.js'
 
 import { waitForRefreshingProjects } from '../project/refresh.js'
 import { formatSourceText } from './format-source-text.js'

--- a/packages/renoun/src/utils/get-symbol-description.test.ts
+++ b/packages/renoun/src/utils/get-symbol-description.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from 'vitest'
-import { Project, SyntaxKind } from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+
+const { Project, SyntaxKind } = getTsMorph()
 
 import { getSymbolDescription } from './get-symbol-description.js'
 

--- a/packages/renoun/src/utils/get-symbol-description.ts
+++ b/packages/renoun/src/utils/get-symbol-description.ts
@@ -1,5 +1,7 @@
-import type { Symbol } from 'ts-morph'
-import tsMorph from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+import type { Symbol } from './ts-morph.js'
+
+const tsMorph = getTsMorph()
 
 /** Gets the description from a symbol's JSDoc or leading comment range. */
 export function getSymbolDescription(symbol: Symbol) {

--- a/packages/renoun/src/utils/get-tokens.ts
+++ b/packages/renoun/src/utils/get-tokens.ts
@@ -1,6 +1,6 @@
 import { join, posix } from 'node:path'
-import type { Diagnostic, Project, SourceFile, ts } from 'ts-morph'
-import tsMorph from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+import type { Diagnostic, Project, SourceFile, ts } from './ts-morph.js'
 
 import type { ConfigurationOptions } from '../components/Config/types.js'
 import type { Languages as TextMateLanguages } from '../grammars/index.js'
@@ -13,6 +13,7 @@ import { isJsxOnly } from './is-jsx-only.js'
 import { generatedFilenames } from './get-source-text-metadata.js'
 import { splitTokenByRanges } from './split-tokens-by-ranges.js'
 
+const tsMorph = getTsMorph()
 const { Node, SyntaxKind } = tsMorph
 
 type Color = string

--- a/packages/renoun/src/utils/resolve-expressions.test.ts
+++ b/packages/renoun/src/utils/resolve-expressions.test.ts
@@ -1,11 +1,13 @@
 import { describe, test, expect } from 'vitest'
-import { Project, SyntaxKind } from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
 
 import {
   resolveLiteralExpression,
   resolveArrayLiteralExpression,
   resolveObjectLiteralExpression,
 } from './resolve-expressions.js'
+
+const { Project, SyntaxKind } = getTsMorph()
 
 const project = new Project()
 

--- a/packages/renoun/src/utils/resolve-expressions.ts
+++ b/packages/renoun/src/utils/resolve-expressions.ts
@@ -1,9 +1,11 @@
+import { getTsMorph } from './ts-morph.js'
 import type {
   ArrayLiteralExpression,
   Expression,
   ObjectLiteralExpression,
-} from 'ts-morph'
-import tsMorph from 'ts-morph'
+} from './ts-morph.js'
+
+const tsMorph = getTsMorph()
 
 const { Node } = tsMorph
 

--- a/packages/renoun/src/utils/resolve-type-at-location.ts
+++ b/packages/renoun/src/utils/resolve-type-at-location.ts
@@ -1,9 +1,11 @@
-import type { Project } from 'ts-morph'
-import { SyntaxKind } from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+import type { Project, SyntaxKind as TsMorphSyntaxKind } from './ts-morph.js'
 
 import { getDebugLogger } from './debug.js'
 import type { Kind, TypeFilter } from './resolve-type.js'
 import { resolveType } from './resolve-type.js'
+
+const { SyntaxKind } = getTsMorph()
 
 export const resolvedTypeCache = new Map<
   string,
@@ -18,7 +20,7 @@ export async function resolveTypeAtLocation(
   project: Project,
   filePath: string,
   position: number,
-  kind: SyntaxKind,
+  kind: TsMorphSyntaxKind,
   filter?: TypeFilter,
   isMemoryFileSystem = false
 ) {

--- a/packages/renoun/src/utils/resolve-type.test.ts
+++ b/packages/renoun/src/utils/resolve-type.test.ts
@@ -1,13 +1,11 @@
 import { describe, test, expect } from 'vitest'
-import {
-  Project,
-  SyntaxKind,
-  type ClassDeclaration,
-  type FunctionDeclaration,
-} from 'ts-morph'
+import { getTsMorph } from './ts-morph.js'
+import type { ClassDeclaration, FunctionDeclaration } from './ts-morph.js'
 import dedent from 'dedent'
 
 import { resolveType } from './resolve-type.js'
+
+const { Project, SyntaxKind } = getTsMorph()
 
 const project = new Project()
 

--- a/packages/renoun/src/utils/transpile-source-file.ts
+++ b/packages/renoun/src/utils/transpile-source-file.ts
@@ -1,4 +1,4 @@
-import type { Project } from 'ts-morph'
+import type { Project } from './ts-morph.js'
 
 import { getDiagnosticMessageText } from './get-diagnostic-message.js'
 

--- a/packages/renoun/src/utils/ts-morph.ts
+++ b/packages/renoun/src/utils/ts-morph.ts
@@ -1,0 +1,15 @@
+import { createRequire } from 'node:module'
+
+let cachedTsMorph: typeof import('ts-morph') | undefined
+
+/** Lazily load the CommonJS ts-morph package in Node environments. */
+export function getTsMorph(): typeof import('ts-morph') {
+  if (cachedTsMorph === undefined) {
+    const require = createRequire(import.meta.url)
+    cachedTsMorph = require('ts-morph') as typeof import('ts-morph')
+  }
+
+  return cachedTsMorph
+}
+
+export type * from 'ts-morph'


### PR DESCRIPTION
Fixes `ts-morph` erroring in Vite builds by loading the package dynamically to resolve the CommonJS module at runtime.

closes #328
