### PR TITLE
add Cursor URI scheme

### DIFF
--- a/.changeset/cursor-editor-config.md
+++ b/.changeset/cursor-editor-config.md
@@ -1,0 +1,5 @@
+---
+'renoun': minor
+---
+
+Adds Cursor to the supported editor URI schemes and allows configuring the editor through `RootProvider`.

--- a/apps/site/docs/03.configuration.mdx
+++ b/apps/site/docs/03.configuration.mdx
@@ -287,6 +287,28 @@ export default function RootLayout({
 }
 ```
 
+## Editor Links
+
+Control which IDE is used when constructing editor URIs by setting the `editor` prop. Any editor supported by [`getEditorUri`](https://renoun.dev/docs/components/link#variants) can be provided, including VS Code compatible editors and JetBrains IDEs.
+
+```tsx
+import { RootProvider } from 'renoun'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <RootProvider editor="cursor">
+      <html>
+        <body>{children}</body>
+      </html>
+    </RootProvider>
+  )
+}
+```
+
 ## Git Information
 
 Set `git` on `RootProvider` to enable edit/source links and canonical URLs:

--- a/packages/renoun/src/components/Config/default-config.ts
+++ b/packages/renoun/src/components/Config/default-config.ts
@@ -5,6 +5,7 @@ import type { ConfigurationOptions } from './types'
  * @internal
  */
 export const defaultConfig: ConfigurationOptions = {
+  editor: 'vscode',
   languages: [
     'css',
     'js',

--- a/packages/renoun/src/components/Config/types.ts
+++ b/packages/renoun/src/components/Config/types.ts
@@ -1,4 +1,5 @@
 import type { Languages, Themes } from '../../grammars/index.js'
+import type { Editors } from '../../utils/get-editor-uri.js'
 
 /**
  * The theme name.
@@ -74,4 +75,7 @@ export interface ConfigurationOptions {
 
   /** The default package manager used by the `Install` component. */
   defaultPackageManager?: 'npm' | 'pnpm' | 'yarn' | 'bun'
+
+  /** The default editor used when constructing editor URIs. */
+  editor?: Editors
 }

--- a/packages/renoun/src/components/Link/Link.tsx
+++ b/packages/renoun/src/components/Link/Link.tsx
@@ -124,6 +124,27 @@ RootProvider with a valid git object or shorthand (e.g. "owner/repo#branch").`
       }
     }
 
+    if (methodName === 'getEditorUri') {
+      const editorOptions =
+        options && typeof options === 'object'
+          ? { ...(options as Record<string, any>) }
+          : undefined
+
+      if (
+        config.editor &&
+        (editorOptions?.['editor'] === undefined ||
+          editorOptions?.['editor'] === null)
+      ) {
+        if (editorOptions) {
+          editorOptions['editor'] = config.editor
+        } else {
+          return method.call(source, { editor: config.editor })
+        }
+      }
+
+      return method.call(source, editorOptions)
+    }
+
     const needsRepository = methodName.endsWith('Url')
     const href = needsRepository
       ? method.call(source, {

--- a/packages/renoun/src/components/RootProvider.mdx
+++ b/packages/renoun/src/components/RootProvider.mdx
@@ -1,4 +1,4 @@
-The `RootProvider` component configures renoun at the root of your application. It must wrap the `html` element and provides configuration for themes, languages, git info, and the site URL.
+The `RootProvider` component configures renoun at the root of your application. It must wrap the `html` element and provides configuration for themes, languages, git info, editor links, and the site URL.
 
 ```tsx
 import { RootProvider } from 'renoun'

--- a/packages/renoun/src/components/RootProvider.tsx
+++ b/packages/renoun/src/components/RootProvider.tsx
@@ -59,6 +59,7 @@ export function RootProvider<Theme extends ThemeValue | ThemeMap | undefined>({
   languages,
   git,
   siteUrl,
+  editor,
   defaultPackageManager = 'npm',
   includeCommandScript = true,
   includeTableOfContentsScript = true,
@@ -71,6 +72,9 @@ export function RootProvider<Theme extends ThemeValue | ThemeMap | undefined>({
   }
   if (languages !== undefined) {
     overrides.languages = languages
+  }
+  if (editor !== undefined) {
+    overrides.editor = editor
   }
   if (git !== undefined) {
     if (typeof git === 'string') {

--- a/packages/renoun/src/file-system/index.tsx
+++ b/packages/renoun/src/file-system/index.tsx
@@ -22,7 +22,10 @@ import { Markdown, type MarkdownComponents } from '../components/Markdown.js'
 import { getFileExportMetadata } from '../project/client.js'
 import { formatNameAsTitle } from '../utils/format-name-as-title.js'
 import { getClosestFile } from '../utils/get-closest-file.js'
-import { getEditorUri } from '../utils/get-editor-uri.js'
+import {
+  getEditorUri,
+  type GetEditorUriOptions,
+} from '../utils/get-editor-uri.js'
 import type { ModuleExport } from '../utils/get-file-exports.js'
 import { getLocalGitFileMetadata } from '../utils/get-local-git-file-metadata.js'
 import {
@@ -547,8 +550,13 @@ export class File<
   }
 
   /** Get the URI to the file source code for the configured editor. */
-  getEditorUri() {
-    return getEditorUri({ path: this.getAbsolutePath() })
+  getEditorUri(options?: Omit<GetEditorUriOptions, 'path'>) {
+    return getEditorUri({
+      path: this.getAbsolutePath(),
+      line: options?.line,
+      column: options?.column,
+      editor: options?.editor,
+    })
   }
 
   /** Get the first local git commit date of the file. */
@@ -989,7 +997,7 @@ export class JavaScriptModuleExport<Value> {
   }
 
   /** Get the URI to the file export source code for the configured editor. */
-  getEditorUri() {
+  getEditorUri(options?: Omit<GetEditorUriOptions, 'path'>) {
     const path = this.#file.getAbsolutePath()
 
     if (this.#metadata?.location) {
@@ -997,12 +1005,18 @@ export class JavaScriptModuleExport<Value> {
 
       return getEditorUri({
         path,
-        line: location.position.start.line,
-        column: location.position.start.column,
+        line: options?.line ?? location.position.start.line,
+        column: options?.column ?? location.position.start.column,
+        editor: options?.editor,
       })
     }
 
-    return getEditorUri({ path })
+    return getEditorUri({
+      path,
+      line: options?.line,
+      column: options?.column,
+      editor: options?.editor,
+    })
   }
 
   /** Get the resolved type of the export. */
@@ -1452,8 +1466,8 @@ export class MDXModuleExport<Value> {
     return createSlug(this.getName(), this.#slugCasing)
   }
 
-  getEditorUri() {
-    return this.#file.getEditorUri()
+  getEditorUri(options?: Omit<GetEditorUriOptions, 'path'>) {
+    return this.#file.getEditorUri(options)
   }
 
   getEditUrl(
@@ -2972,8 +2986,11 @@ export class Directory<
   }
 
   /** Get the URI to the directory source code for the configured editor. */
-  getEditorUri() {
-    return getEditorUri({ path: this.getAbsolutePath() })
+  getEditorUri(options?: Pick<GetEditorUriOptions, 'editor'>) {
+    return getEditorUri({
+      path: this.getAbsolutePath(),
+      editor: options?.editor,
+    })
   }
 
   /** Get the first local git commit date of this directory. */

--- a/packages/renoun/src/utils/get-editor-uri.test.ts
+++ b/packages/renoun/src/utils/get-editor-uri.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { getEditorUri } from './get-editor-uri.js'
+
+describe('getEditorUri', () => {
+  it('defaults to vscode-compatible scheme', () => {
+    expect(
+      getEditorUri({
+        path: '/workspace/renoun/packages/renoun/src/index.ts',
+      })
+    ).toBe(
+      'vscode://file//workspace/renoun/packages/renoun/src/index.ts:0:0'
+    )
+  })
+
+  it('supports the cursor editor scheme', () => {
+    expect(
+      getEditorUri({
+        path: '/workspace/renoun/packages/renoun/src/index.ts',
+        editor: 'cursor',
+        line: 12,
+        column: 4,
+      })
+    ).toBe(
+      'cursor://file//workspace/renoun/packages/renoun/src/index.ts:12:4'
+    )
+  })
+})

--- a/packages/renoun/src/utils/get-editor-uri.ts
+++ b/packages/renoun/src/utils/get-editor-uri.ts
@@ -2,6 +2,7 @@ export type Editors =
   | 'vscode'
   | 'vscode-insiders'
   | 'vscodium'
+  | 'cursor'
   | 'android-studio'
   | 'idea'
   | 'phpstorm'
@@ -34,6 +35,7 @@ export function getEditorUri({
     case 'vscode':
     case 'vscode-insiders':
     case 'vscodium':
+    case 'cursor':
       return `${editor}://file/${path}:${line}:${column}`
 
     case 'android-studio':
@@ -50,7 +52,7 @@ export function getEditorUri({
 
     default:
       throw new Error(
-        `Unsupported editor: ${editor}. Supported editors are: vscode, vscode-insiders, vscodium, sublime, phpstorm, webstorm, idea, android-studio, textmate.`
+        `Unsupported editor: ${editor}. Supported editors are: vscode, vscode-insiders, vscodium, cursor, sublime, phpstorm, webstorm, idea, android-studio, textmate.`
       )
   }
 }


### PR DESCRIPTION
Adds Cursor to the supported editor URI schemes and allows configuring the editor through `RootProvider`.
