### PR TITLE
improve resolving JSDoc types

### DIFF
--- a/.changeset/jsdoc-default-values-and-flags.md
+++ b/.changeset/jsdoc-default-values-and-flags.md
@@ -1,0 +1,5 @@
+---
+'renoun': minor
+---
+
+Improves JSDoc support in `JavaScriptModuleExport#getType`.


### PR DESCRIPTION
Improves JSDoc support in `JavaScriptModuleExport#getType`:

- Parses optional/rest parameters from JSDoc, including bracket-optional `@param {Type} [name]` and variadic `@param {...Type} name`.
- Captures JSDoc default values from bracketed params `@param {Type} [name=default]` as the parameter `initializer` (strings, numbers, booleans, null, undefined, arrays/objects via JSON).
- Resolves properties from `@typedef {Object}` with `@property` (including bracket-optional properties).
- Recognizes `@returns {Type}` for JS functions.
- Handles `JSDocOptionalType` and `JSDocVariadicType` in unwrap logic.
