### PR TITLE
improve file system performance

### DIFF
--- a/.changeset/granular-directory-snapshots-and-type-invalidation.md
+++ b/.changeset/granular-directory-snapshots-and-type-invalidation.md
@@ -1,0 +1,5 @@
+---
+'renoun': minor
+---
+
+Improves file-system utility performance and local developer experience by using granular directory snapshots and more robust type resolution.

--- a/packages/renoun/src/file-system/FileSystem.ts
+++ b/packages/renoun/src/file-system/FileSystem.ts
@@ -116,6 +116,17 @@ export abstract class FileSystem {
     return this.fileExistsSync(path)
   }
 
+  /**
+   * Get the last modified timestamp of a file or directory in milliseconds.
+   * Implementations should return `undefined` if the path does not exist or
+   * if the timestamp cannot be determined.
+   */
+  abstract getFileLastModifiedMsSync(path: string): number | undefined
+
+  async getFileLastModifiedMs(path: string): Promise<number | undefined> {
+    return this.getFileLastModifiedMsSync(path)
+  }
+
   abstract deleteFileSync(path: string): void
 
   abstract deleteFile(path: string): Promise<void>

--- a/packages/renoun/src/file-system/MemoryFileSystem.ts
+++ b/packages/renoun/src/file-system/MemoryFileSystem.ts
@@ -415,6 +415,17 @@ export class MemoryFileSystem extends FileSystem {
     const normalized = normalizeSlashes(filePath).replace(/^\.\//, '')
     return this.#ignore(normalized)
   }
+
+  getFileLastModifiedMsSync(_path: string): number | undefined {
+    // Memory file systems do not have real modification timestamps.
+    // Callers should treat `undefined` as "unknown" and avoid relying on it
+    // for cache invalidation.
+    return undefined
+  }
+
+  async getFileLastModifiedMs(path: string): Promise<number | undefined> {
+    return this.getFileLastModifiedMsSync(path)
+  }
 }
 
 /** Concatenate Uint8Arrays into a single Uint8Array. */

--- a/packages/renoun/src/file-system/NodeFileSystem.ts
+++ b/packages/renoun/src/file-system/NodeFileSystem.ts
@@ -6,9 +6,10 @@ import {
   rmSync,
   createReadStream,
   createWriteStream,
+  statSync,
   type Dirent,
 } from 'node:fs'
-import { access, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { access, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import { ensureRelativePath, relativePath } from '../utils/path.js'
@@ -168,6 +169,25 @@ export class NodeFileSystem extends FileSystem {
 
   isFilePathGitIgnored(filePath: string): boolean {
     return isFilePathGitIgnored(filePath)
+  }
+
+  getFileLastModifiedMsSync(path: string): number | undefined {
+    this.#assertWithinWorkspace(path)
+    try {
+      return statSync(path).mtimeMs
+    } catch {
+      return undefined
+    }
+  }
+
+  async getFileLastModifiedMs(path: string): Promise<number | undefined> {
+    this.#assertWithinWorkspace(path)
+    try {
+      const stats = await stat(path)
+      return stats.mtimeMs
+    } catch {
+      return undefined
+    }
   }
 }
 

--- a/packages/renoun/src/file-system/directory-snapshot.ts
+++ b/packages/renoun/src/file-system/directory-snapshot.ts
@@ -1,0 +1,84 @@
+import type { Directory, FileSystemEntry } from './index'
+
+export interface DirectorySnapshotDirectoryMetadata<
+  LoaderTypes extends Record<string, any>,
+> {
+  hasVisibleDescendant: boolean
+  materializedEntries: FileSystemEntry<LoaderTypes>[]
+}
+
+export class DirectorySnapshot<
+  LoaderTypes extends Record<string, any>,
+> {
+  #entries: FileSystemEntry<LoaderTypes>[]
+  #directories: Map<
+    Directory<LoaderTypes>,
+    DirectorySnapshotDirectoryMetadata<LoaderTypes>
+  >
+  #materialized?: FileSystemEntry<LoaderTypes>[]
+  #dependencies?: Map<string, number>
+
+  constructor(options: {
+    entries: FileSystemEntry<LoaderTypes>[]
+    directories: Map<
+      Directory<LoaderTypes>,
+      DirectorySnapshotDirectoryMetadata<LoaderTypes>
+    >
+    shouldIncludeSelf: boolean
+    hasVisibleDescendant: boolean
+    dependencies?: Map<string, number>
+  }) {
+    this.#entries = options.entries
+    this.#directories = options.directories
+    this.shouldIncludeSelf = options.shouldIncludeSelf
+    this.hasVisibleDescendant = options.hasVisibleDescendant
+    this.#dependencies = options.dependencies
+  }
+
+  readonly shouldIncludeSelf: boolean
+  hasVisibleDescendant: boolean
+
+  materialize(): FileSystemEntry<LoaderTypes>[] {
+    if (!this.#materialized) {
+      this.#materialized = this.#entries.slice()
+    }
+
+    return this.#materialized
+  }
+
+  getDirectoryMetadata(
+    directory: Directory<LoaderTypes>
+  ): DirectorySnapshotDirectoryMetadata<LoaderTypes> | undefined {
+    return this.#directories.get(directory)
+  }
+
+  getDependencies(): Map<string, number> | undefined {
+    return this.#dependencies
+  }
+}
+
+export function createDirectorySnapshot<
+  LoaderTypes extends Record<string, any>,
+>(options: {
+  entries: FileSystemEntry<LoaderTypes>[]
+  directories?: Map<
+    Directory<LoaderTypes>,
+    DirectorySnapshotDirectoryMetadata<LoaderTypes>
+  >
+  shouldIncludeSelf: boolean
+  hasVisibleDescendant: boolean
+  dependencies?: Map<string, number>
+}): DirectorySnapshot<LoaderTypes> {
+  return new DirectorySnapshot({
+    entries: options.entries,
+    directories:
+      options.directories ??
+      new Map<
+        Directory<LoaderTypes>,
+        DirectorySnapshotDirectoryMetadata<LoaderTypes>
+      >(),
+    shouldIncludeSelf: options.shouldIncludeSelf,
+    hasVisibleDescendant: options.hasVisibleDescendant,
+    dependencies: options.dependencies,
+  })
+}

--- a/packages/renoun/src/file-system/index.test.ts
+++ b/packages/renoun/src/file-system/index.test.ts
@@ -289,6 +289,33 @@ describe('file system', () => {
     expect(entries).toHaveLength(2)
   })
 
+  test('reuses cached snapshots for identical getEntries options', async () => {
+    const fileSystem = new MemoryFileSystem({
+      'index.ts': '',
+      'components/Button/index.tsx': '',
+      'components/Button/Button.tsx': '',
+    })
+    const readDirectorySpy = vi.spyOn(fileSystem, 'readDirectory')
+    const directory = new Directory({ fileSystem })
+
+    await directory.getEntries({
+      recursive: true,
+      includeDirectoryNamedFiles: true,
+      includeIndexAndReadmeFiles: true,
+    })
+
+    const callsAfterFirst = readDirectorySpy.mock.calls.length
+
+    await directory.getEntries({
+      recursive: true,
+      includeDirectoryNamedFiles: true,
+      includeIndexAndReadmeFiles: true,
+    })
+
+    expect(readDirectorySpy).toHaveBeenCalledTimes(callsAfterFirst)
+    readDirectorySpy.mockRestore()
+  })
+
   test('recursive entries', async () => {
     const directory = new Directory({ path: 'fixtures/project' })
     const entries = await directory.getEntries({

--- a/packages/renoun/src/project/server.ts
+++ b/packages/renoun/src/project/server.ts
@@ -160,7 +160,10 @@ export async function createServer(options?: { port?: number }) {
       )
     },
     {
-      memoize: true,
+      // Type resolution already has its own dependency-aware cache
+      // (see `resolve-type-at-location.ts`). Avoid RPC-level memoization
+      // so changes to source or its dependencies are always reflected.
+      memoize: false,
       concurrency: 3,
     }
   )

--- a/packages/renoun/src/utils/resolve-type-at-location.ts
+++ b/packages/renoun/src/utils/resolve-type-at-location.ts
@@ -32,7 +32,7 @@ export async function resolveTypeAtLocation(
     async () => {
       const sourceFile = project.addSourceFileAtPath(filePath)
 
-      let declaration = sourceFile.getDescendantAtPos(position)
+      const declaration = sourceFile.getDescendantAtPos(position)
 
       if (!declaration) {
         throw new Error(
@@ -40,7 +40,10 @@ export async function resolveTypeAtLocation(
         )
       }
 
-      const exportDeclaration = declaration.getFirstAncestorByKind(kind)
+      const exportDeclaration =
+        declaration.getKind() === kind
+          ? declaration
+          : declaration.getFirstAncestorByKind(kind)
 
       if (!exportDeclaration) {
         throw new Error(


### PR DESCRIPTION
Improves file-system utility performance and local developer experience by using granular directory snapshots and more robust type resolution:

- Adds directory snapshots that cache the results of `Directory#getEntries` keyed by options while tracking per-entry dependencies and invalidating snapshots only when the underlying files change (based on `mtime`), rather than using a single coarse global cache.
- Ensures snapshots are automatically invalidated when files are written or deleted through the `File` API, and when source files change on disk during development.
- Refines the type resolution pipeline used by `Reference`/`JavaScriptModuleExport#getType` so that export metadata (positions and kinds) refresh on each request, avoiding stale positions when the underlying TypeScript source changes.
- Removes redundant RPC-level memoization for `resolveTypeAtLocation` in favor of the dependency-aware cache in `resolve-type-at-location`, and slightly hardens the resolver to prefer exact-kind nodes before walking ancestors.

